### PR TITLE
Release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
 - Labels can be added, changed, or removed at any time via the integration's settings
 - Unlabelled plants always appear first within their area
 
+### 🔬 Latin Name (optional)
+- Store the scientific name for each plant
+- Enabled or disabled per plant during setup or via Configure at any time
+- Displayed on the companion card below the plant name (if enabled)
+> **Tip:** To remove a latin name after setup, open Configure and toggle Enable latin name off.
+
 ---
 
 ## Installation
@@ -85,6 +91,7 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
    - Last watered date (Today / Yesterday / Custom / Haven't yet)
    - Last fertilized date (if enabled)
    - Image path (if enabled)
+   - Add Latin name (if enabled)
    - Moisture thresholds (if a sensor was selected)
 
 To edit any setting after setup, go to **Settings → Devices & Services → Adaptive Plant → Configure**.
@@ -116,6 +123,7 @@ Each plant creates a device with the following entities:
 | Mark fertilized | Button | *(if fertilization enabled)* |
 | Notes | Text | *(if notes enabled)* |
 | Soil moisture | Sensor | Diagnostic — live reading from linked moisture sensor *(if moisture sensor configured)* |
+|Latin name | Text | (if latin name enabled)
 ---
 
 ## Adaptive Logic
@@ -126,7 +134,7 @@ If you press **Mark Watered** before the scheduled date, an early watering count
 ### Watering interval extension
 If you press **Snooze today's tasks** during a watering period and then water the plant, a snooze streak counter increments. Once it reaches the configured threshold across consecutive periods, the watering interval increases by 1 day (maximum 365). The streak resets if you water without snoozing.
 
-> **Note:** Snoozing and then watering the same plant on the same day will count that period as both early and snoozed. This is a known edge case that will be addressed in a future release.
+> **Note:** Snoozing and then watering the same plant on the same day will count that period as both early and snoozed. This is a known edge case and _may_ be addressed in a future release. In the meantime.... don't do that? Why would you do that? 
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
 - Track fertilization on a separate interval
 - Same sensor pattern as watering
 - Snoozing watering also snoozes fertilization if it is due the same day
+- Can be enabled on any plant after setup via Configure — you'll be prompted for the last fertilized date when first enabled
+- When enabling fertilization on an existing plant, set your desired interval via the device page or Configure **after** saving the last fertilized date. Then press **Mark fertilized** once for the new interval to take effect and for Days until fertilization to calculate correctly from that date.
+
+### 🪴 Repotting (optional)
+- Track when a plant was last repotted via the **Last repotted** date sensor
+- **Mark repotted** button stamps today's date as the last repotting event
+- **Repotted on** text field — enter a date in `YYYY-MM-DD` format (e.g. `2026-04-01`) before pressing Mark repotted to record a past date instead of today. The field clears automatically after the button is pressed.
+- Can be enabled on any plant after setup via Configure — you'll be prompted for the last repotted date when first enabled
+
+> **Note:** The **Repotted on** field accepts dates in `YYYY-MM-DD` format only (e.g. `2026-04-01`). Invalid entries are ignored and Mark repotted will fall back to today's date.
 
 ### 💧 Moisture Sensor Integration (optional)
 - Link any existing sensor entity
@@ -63,6 +73,7 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
 - Store the scientific name for each plant
 - Enabled or disabled per plant during setup or via Configure at any time
 - Displayed on the companion card below the plant name (if enabled)
+
 > **Tip:** To remove a latin name after setup, open Configure and toggle Enable latin name off.
 
 ---
@@ -87,12 +98,13 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
 2. Search for **Adaptive Plant**
 3. Follow the setup wizard:
    - Plant name, area, optional label, watering interval, adaptive thresholds
-   - Optional features (fertilization, notes, image, moisture sensor)
+   - Optional features (fertilization, notes, latin name, image, repotting, moisture sensor)
    - Last watered date (Today / Yesterday / Custom / Haven't yet)
-   - Last fertilized date (if enabled)
-   - Image path (if enabled)
-   - Add Latin name (if enabled)
-   - Moisture thresholds (if a sensor was selected)
+   - Last fertilized date (Today / Yesterday / Custom / Haven't yet) *(if fertilization enabled)*
+   - Last repotted date (Today / Yesterday / Custom / Haven't yet) *(if repotting enabled)*
+   - Latin name *(if latin name enabled)*
+   - Image path *(if image enabled)*
+   - Moisture thresholds *(if a sensor was selected)*
 
 To edit any setting after setup, go to **Settings → Devices & Services → Adaptive Plant → Configure**.
 
@@ -121,9 +133,13 @@ Each plant creates a device with the following entities:
 | Days until fertilization | Sensor | *(if fertilization enabled)* |
 | Fertilization interval | Number | *(if fertilization enabled)* |
 | Mark fertilized | Button | *(if fertilization enabled)* |
+| Last repotted | Sensor | *(if repotting enabled)* |
+| Mark repotted | Button | *(if repotting enabled)* Stamps today's date, or the date in the Repotted on field if set |
+| Repotted on | Text | *(if repotting enabled)* Enter a past date in `YYYY-MM-DD` format before pressing Mark repotted |
 | Notes | Text | *(if notes enabled)* |
+| Latin name | Text | *(if latin name enabled)* |
 | Soil moisture | Sensor | Diagnostic — live reading from linked moisture sensor *(if moisture sensor configured)* |
-|Latin name | Text | (if latin name enabled)
+
 ---
 
 ## Adaptive Logic
@@ -134,7 +150,7 @@ If you press **Mark Watered** before the scheduled date, an early watering count
 ### Watering interval extension
 If you press **Snooze today's tasks** during a watering period and then water the plant, a snooze streak counter increments. Once it reaches the configured threshold across consecutive periods, the watering interval increases by 1 day (maximum 365). The streak resets if you water without snoozing.
 
-> **Note:** Snoozing and then watering the same plant on the same day will count that period as both early and snoozed. This is a known edge case and _may_ be addressed in a future release. In the meantime.... don't do that? Why would you do that? 
+> **Note:** Snoozing and then watering the same plant on the same day will count that period as both early and snoozed. This is a known edge case and _may_ be addressed in a future release. In the meantime.... don't do that? Why would you do that?
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A fully local, event-driven Home Assistant custom integration for tracking and m
 
 ### 📝 Notes (optional)
 - Free-form text field stored per plant
+- Can be enabled or disabled at any time via Configure — no restart required
 
 ### 🖼️ Plant Image (optional)
 - Attach a `/local/` image path to display on dashboard cards. Can be changed via configuration after entry is created. I recommend uploading your plant images to your `/www/` folder.

--- a/blueprints/automation/adaptive_plant/plant_task_reminders.yaml
+++ b/blueprints/automation/adaptive_plant/plant_task_reminders.yaml
@@ -231,8 +231,8 @@ condition:
   - condition: template
     value_template: >
       {% set now_str = now().strftime('%H:%M') %}
-      {% set t2 = reminder_time_2 | trim | truncate(5, false, '') %}
-      {% set t3 = reminder_time_3 | trim | truncate(5, false, '') %}
+      {% set t2 = (reminder_time_2 | trim)[:5] %}
+      {% set t3 = (reminder_time_3 | trim)[:5] %}
       {% if trigger.id == 'time_1' %}
         true
       {% elif trigger.id == 'time_check' %}

--- a/custom_components/adaptive_plant/__init__.py
+++ b/custom_components/adaptive_plant/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     STATE_HEALTH,
     STATE_HEALTH_LAST_UPDATED,
     STATE_LAST_FERTILIZED,
+    STATE_LAST_REPOTTED,
     STATE_LAST_WATERED,
     STATE_NEXT_FERTILIZED,
     STATE_NEXT_WATERING,
@@ -54,6 +55,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if last_fertilized:
             initial_options[STATE_LAST_FERTILIZED] = last_fertilized
         initial_options[STATE_NEXT_FERTILIZED] = next_fertilized
+        seeded = True
+
+    # Seed last_repotted from setup wizard on first load
+    resolved_last_repotted = entry.data.get("_resolved_last_repotted")
+    if resolved_last_repotted and STATE_LAST_REPOTTED not in initial_options:
+        initial_options[STATE_LAST_REPOTTED] = resolved_last_repotted
         seeded = True
 
     # Seed watering interval from data into options if not already there

--- a/custom_components/adaptive_plant/button.py
+++ b/custom_components/adaptive_plant/button.py
@@ -22,10 +22,11 @@ async def async_setup_entry(
         MarkWateredButton(plant, entry),
         SnoozeWateringButton(plant, entry),
         ConfirmHealthButton(plant, entry),
+        MarkFertilizedButton(plant, entry),
     ]
 
-    if plant.enable_fertilization:
-        entities.append(MarkFertilizedButton(plant, entry))
+    if plant.enable_repotting:
+        entities.append(MarkRepottedButton(plant, entry))
 
     async_add_entities(entities)
 
@@ -88,6 +89,10 @@ class MarkFertilizedButton(PlantButtonBase):
         super().__init__(plant, entry)
         self._attr_unique_id = f"{entry.entry_id}_mark_fertilized"
 
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_fertilization
+
     async def async_press(self) -> None:
         await self._plant.mark_fertilized()
 
@@ -104,3 +109,21 @@ class ConfirmHealthButton(PlantButtonBase):
 
     async def async_press(self) -> None:
         await self._plant.confirm_health()
+
+
+class MarkRepottedButton(PlantButtonBase):
+    """Button that records the current date as the last repotting event."""
+
+    _attr_translation_key = "mark_repotted"
+    _attr_icon = "mdi:pot-mix"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        super().__init__(plant, entry)
+        self._attr_unique_id = f"{entry.entry_id}_mark_repotted"
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_repotting
+
+    async def async_press(self) -> None:
+        await self._plant.mark_repotted()

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -48,7 +48,6 @@ WATERING_DATE_NEVER = "never"
 def _basic_schema(defaults: dict) -> vol.Schema:
     return vol.Schema({
         vol.Required(CONF_PLANT_NAME, default=defaults.get(CONF_PLANT_NAME, "")): selector.selector({"text": {}}),
-        vol.Optional(CONF_LATIN_NAME, default=defaults.get(CONF_LATIN_NAME, "")): selector.selector({"text": {}}),
         vol.Optional(CONF_AREA): selector.selector({"area": {}}),
         vol.Optional(CONF_LABEL, default=defaults.get(CONF_LABEL, "")): selector.selector({"text": {}}),
         vol.Required(OPT_WATERING_INTERVAL, default=defaults.get(OPT_WATERING_INTERVAL, DEFAULT_WATERING_INTERVAL)): selector.selector(
@@ -126,6 +125,14 @@ def _fertilize_schema(defaults: dict) -> vol.Schema:
     return vol.Schema({
         vol.Required(OPT_FERTILIZATION_INTERVAL, default=defaults.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL)): selector.selector(
             {"number": {"min": 1, "max": 365, "mode": "box", "unit_of_measurement": "days"}}
+        ),
+    })
+
+
+def _latin_name_schema(defaults: dict) -> vol.Schema:
+    return vol.Schema({
+        vol.Optional(CONF_LATIN_NAME, default=defaults.get(CONF_LATIN_NAME, "")): selector.selector(
+            {"text": {}}
         ),
     })
 
@@ -224,6 +231,8 @@ class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _after_watering(self) -> FlowResult:
         if self._data.get(CONF_ENABLE_FERTILIZATION):
             return await self.async_step_fertilize()
+        if self._data.get(CONF_ENABLE_LATIN_NAME):
+            return await self.async_step_latin_name()
         if self._data.get(CONF_ENABLE_IMAGE):
             return await self.async_step_image()
         if self._data.get(CONF_MOISTURE_SENSOR):
@@ -264,11 +273,28 @@ class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="last_fertilized_custom", data_schema=_last_fertilized_custom_schema(), errors=errors)
 
     async def _after_fertilizing(self) -> FlowResult:
+        if self._data.get(CONF_ENABLE_LATIN_NAME):
+            return await self.async_step_latin_name()
         if self._data.get(CONF_ENABLE_IMAGE):
             return await self.async_step_image()
         if self._data.get(CONF_MOISTURE_SENSOR):
             return await self.async_step_moisture()
         return self._create_entry()
+
+    async def async_step_latin_name(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            name = user_input.get(CONF_LATIN_NAME, "").strip()
+            if name:
+                self._data[CONF_LATIN_NAME] = name
+            if self._data.get(CONF_ENABLE_IMAGE):
+                return await self.async_step_image()
+            if self._data.get(CONF_MOISTURE_SENSOR):
+                return await self.async_step_moisture()
+            return self._create_entry()
+        return self.async_show_form(
+            step_id="latin_name",
+            data_schema=_latin_name_schema(self._data),
+        )
 
     async def async_step_image(self, user_input: dict | None = None) -> FlowResult:
         errors: dict[str, str] = {}
@@ -332,18 +358,19 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 else:
                     cleaned[CONF_LABEL] = lv
 
-            # Notes enabled toggle — stored in options as the runtime override.
-            # Always write it explicitly so toggling off is persisted even when
-            # the value is falsy and would otherwise be stripped by the cleaned filter.
+            # Notes enabled toggle — always write explicitly so falsy value persists
             cleaned[CONF_NOTES_ENABLED] = bool(user_input.get(CONF_NOTES_ENABLED, False))
 
-            # Latin name — normalise blank to absent
-            if CONF_LATIN_NAME in cleaned:
-                ln = cleaned[CONF_LATIN_NAME].strip()
-                if not ln:
-                    del cleaned[CONF_LATIN_NAME]
-                else:
-                    cleaned[CONF_LATIN_NAME] = ln
+            # Latin name toggle — write explicitly, and handle the text field.
+            latin_enabled = bool(user_input.get(CONF_ENABLE_LATIN_NAME, False))
+            cleaned[CONF_ENABLE_LATIN_NAME] = latin_enabled
+            if latin_enabled:
+                # Use key-presence check so empty string is treated as intentional clear
+                raw_latin = user_input.get(CONF_LATIN_NAME, "")
+                cleaned[CONF_LATIN_NAME] = raw_latin.strip() if raw_latin else ""
+            else:
+                # Toggle off — remove stored latin name
+                cleaned.pop(CONF_LATIN_NAME, None)
 
             # Handle moisture sensor selection.
             # The toggle is the authoritative clear mechanism — if it's off we
@@ -364,9 +391,11 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 merged = {**current_opts, **cleaned}
                 for key in (CONF_MOISTURE_SENSOR, CONF_DRY_THRESHOLD, CONF_WET_THRESHOLD):
                     merged.pop(key, None)
-                # Also clear blanked fields
+                # Also clear blanked fields — but skip keys we've already
+                # handled explicitly above (boolean toggles that are legitimately false)
+                _skip_clear = {CONF_NOTES_ENABLED, CONF_ENABLE_LATIN_NAME}
                 for k, v in user_input.items():
-                    if v in (None, "") and k in merged:
+                    if k not in _skip_clear and v in (None, "") and k in merged:
                         del merged[k]
                 return self.async_create_entry(title="", data=merged)
 
@@ -397,21 +426,6 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             ),
         }
 
-        # Notes toggle — always shown so users can enable/disable after setup.
-        # The current state is: options override > entry.data original setting.
-        notes_currently_enabled = bool(
-            current_opts.get(CONF_NOTES_ENABLED, entry.data.get(CONF_ENABLE_NOTES, False))
-        )
-        schema_fields[vol.Required(CONF_NOTES_ENABLED, default=notes_currently_enabled)] = selector.selector(
-            {"boolean": {}}
-        )
-
-        # Latin name — only shown if enabled at setup, editable here.
-        if entry.data.get(CONF_ENABLE_LATIN_NAME):
-            schema_fields[vol.Optional(CONF_LATIN_NAME, default=defaults.get(CONF_LATIN_NAME, ""))] = selector.selector(
-                {"text": {}}
-            )
-
         if entry.data.get(CONF_ENABLE_FERTILIZATION):
             schema_fields[vol.Required(OPT_FERTILIZATION_INTERVAL, default=defaults.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL))] = selector.selector(
                 {"number": {"min": 1, "max": 365, "mode": "box", "unit_of_measurement": "days"}}
@@ -422,10 +436,30 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 {"text": {}}
             )
 
-        # Always show moisture sensor picker so users can add, change, or clear it.
-        # A boolean toggle acts as the clear mechanism since the entity selector
-        # widget cannot be truly blanked in the HA UI (clicking X still submits
-        # the previous value). Toggle off = clear sensor + thresholds.
+        # ── Toggles — grouped together at the bottom ─────────────────────────
+        # Notes toggle — always shown, options override takes priority over entry.data
+        notes_currently_enabled = bool(
+            current_opts.get(CONF_NOTES_ENABLED, entry.data.get(CONF_ENABLE_NOTES, False))
+        )
+        schema_fields[vol.Required(CONF_NOTES_ENABLED, default=notes_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+
+        # Latin name toggle — always shown so users can enable it after setup.
+        # If already enabled, also show the text field to edit the value.
+        latin_currently_enabled = bool(
+            current_opts.get(CONF_ENABLE_LATIN_NAME, entry.data.get(CONF_ENABLE_LATIN_NAME, False))
+        )
+        schema_fields[vol.Required(CONF_ENABLE_LATIN_NAME, default=latin_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+        if latin_currently_enabled:
+            current_latin = current_opts.get(CONF_LATIN_NAME) or entry.data.get(CONF_LATIN_NAME, "")
+            schema_fields[vol.Optional(CONF_LATIN_NAME, default=current_latin)] = selector.selector(
+                {"text": {}}
+            )
+
+        # Moisture sensor toggle + picker — always shown
         has_moisture = bool(current_moisture)
         schema_fields[vol.Required("moisture_sensor_enabled", default=has_moisture)] = selector.selector(
             {"boolean": {}}

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -16,13 +16,16 @@ from .const import (
     CONF_EARLY_WATERING_THRESHOLD,
     CONF_ENABLE_FERTILIZATION,
     CONF_ENABLE_IMAGE,
+    CONF_ENABLE_LATIN_NAME,
     CONF_ENABLE_NOTES,
     CONF_HEALTH_PROMPT_INTERVAL,
     CONF_IMAGE_PATH,
     CONF_INITIAL_LAST_FERTILIZED,
     CONF_INITIAL_LAST_WATERED,
     CONF_LABEL,
+    CONF_LATIN_NAME,
     CONF_MOISTURE_SENSOR,
+    CONF_NOTES_ENABLED,
     CONF_PLANT_NAME,
     CONF_SNOOZE_THRESHOLD,
     CONF_WET_THRESHOLD,
@@ -45,6 +48,7 @@ WATERING_DATE_NEVER = "never"
 def _basic_schema(defaults: dict) -> vol.Schema:
     return vol.Schema({
         vol.Required(CONF_PLANT_NAME, default=defaults.get(CONF_PLANT_NAME, "")): selector.selector({"text": {}}),
+        vol.Optional(CONF_LATIN_NAME, default=defaults.get(CONF_LATIN_NAME, "")): selector.selector({"text": {}}),
         vol.Optional(CONF_AREA): selector.selector({"area": {}}),
         vol.Optional(CONF_LABEL, default=defaults.get(CONF_LABEL, "")): selector.selector({"text": {}}),
         vol.Required(OPT_WATERING_INTERVAL, default=defaults.get(OPT_WATERING_INTERVAL, DEFAULT_WATERING_INTERVAL)): selector.selector(
@@ -66,6 +70,7 @@ def _features_schema(defaults: dict) -> vol.Schema:
     return vol.Schema({
         vol.Required(CONF_ENABLE_FERTILIZATION, default=defaults.get(CONF_ENABLE_FERTILIZATION, False)): selector.selector({"boolean": {}}),
         vol.Required(CONF_ENABLE_NOTES, default=defaults.get(CONF_ENABLE_NOTES, False)): selector.selector({"boolean": {}}),
+        vol.Required(CONF_ENABLE_LATIN_NAME, default=defaults.get(CONF_ENABLE_LATIN_NAME, False)): selector.selector({"boolean": {}}),
         vol.Required(CONF_ENABLE_IMAGE, default=defaults.get(CONF_ENABLE_IMAGE, False)): selector.selector({"boolean": {}}),
         vol.Optional(CONF_MOISTURE_SENSOR): selector.selector(
             {"entity": {"domain": "sensor", "multiple": False}}
@@ -327,6 +332,19 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 else:
                     cleaned[CONF_LABEL] = lv
 
+            # Notes enabled toggle — stored in options as the runtime override.
+            # Always write it explicitly so toggling off is persisted even when
+            # the value is falsy and would otherwise be stripped by the cleaned filter.
+            cleaned[CONF_NOTES_ENABLED] = bool(user_input.get(CONF_NOTES_ENABLED, False))
+
+            # Latin name — normalise blank to absent
+            if CONF_LATIN_NAME in cleaned:
+                ln = cleaned[CONF_LATIN_NAME].strip()
+                if not ln:
+                    del cleaned[CONF_LATIN_NAME]
+                else:
+                    cleaned[CONF_LATIN_NAME] = ln
+
             # Handle moisture sensor selection.
             # The toggle is the authoritative clear mechanism — if it's off we
             # strip the sensor and thresholds regardless of the picker value,
@@ -378,6 +396,21 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 {"number": {"min": 1, "max": 365, "mode": "box", "unit_of_measurement": "days"}}
             ),
         }
+
+        # Notes toggle — always shown so users can enable/disable after setup.
+        # The current state is: options override > entry.data original setting.
+        notes_currently_enabled = bool(
+            current_opts.get(CONF_NOTES_ENABLED, entry.data.get(CONF_ENABLE_NOTES, False))
+        )
+        schema_fields[vol.Required(CONF_NOTES_ENABLED, default=notes_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+
+        # Latin name — only shown if enabled at setup, editable here.
+        if entry.data.get(CONF_ENABLE_LATIN_NAME):
+            schema_fields[vol.Optional(CONF_LATIN_NAME, default=defaults.get(CONF_LATIN_NAME, ""))] = selector.selector(
+                {"text": {}}
+            )
 
         if entry.data.get(CONF_ENABLE_FERTILIZATION):
             schema_fields[vol.Required(OPT_FERTILIZATION_INTERVAL, default=defaults.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL))] = selector.selector(

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -628,6 +628,27 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     CONF_DRY_THRESHOLD: dry,
                     CONF_WET_THRESHOLD: wet,
                 }
+
+                # ── First-enable detection (same as in async_step_init) ───────
+                # Must run here too — when moisture options are collected first,
+                # async_step_init never reaches the detection block in its else branch.
+                fert_first_enable = (
+                    self._pending_opts.get(CONF_FERTILIZATION_ENABLED) is True
+                    and STATE_LAST_FERTILIZED not in current_opts
+                )
+                repot_first_enable = (
+                    self._pending_opts.get(CONF_REPOTTING_ENABLED) is True
+                    and STATE_LAST_REPOTTED not in current_opts
+                )
+
+                if fert_first_enable or repot_first_enable:
+                    self._pending_opts = merged
+                    self._pending_fert_first = fert_first_enable
+                    self._pending_repot_first = repot_first_enable
+                    if fert_first_enable:
+                        return await self.async_step_fertilized_init()
+                    return await self.async_step_repotted_init()
+
                 return self.async_create_entry(title="", data=merged)
 
         return self.async_show_form(

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -18,6 +18,8 @@ from .const import (
     CONF_ENABLE_IMAGE,
     CONF_ENABLE_LATIN_NAME,
     CONF_ENABLE_NOTES,
+    CONF_ENABLE_REPOTTING,
+    CONF_FERTILIZATION_ENABLED,
     CONF_HEALTH_PROMPT_INTERVAL,
     CONF_IMAGE_PATH,
     CONF_INITIAL_LAST_FERTILIZED,
@@ -27,6 +29,8 @@ from .const import (
     CONF_MOISTURE_SENSOR,
     CONF_NOTES_ENABLED,
     CONF_PLANT_NAME,
+    CONF_REPOTTING_ENABLED,
+    CONF_RESOLVED_LAST_REPOTTED,
     CONF_SNOOZE_THRESHOLD,
     CONF_WET_THRESHOLD,
     DEFAULT_EARLY_WATERING_THRESHOLD,
@@ -37,12 +41,17 @@ from .const import (
     DOMAIN,
     OPT_FERTILIZATION_INTERVAL,
     OPT_WATERING_INTERVAL,
+    STATE_LAST_FERTILIZED,
+    STATE_LAST_REPOTTED,
+    STATE_NEXT_FERTILIZED,
 )
 
 WATERING_DATE_TODAY = "today"
 WATERING_DATE_YESTERDAY = "yesterday"
 WATERING_DATE_CUSTOM = "custom"
 WATERING_DATE_NEVER = "never"
+
+CONF_INITIAL_LAST_REPOTTED = "initial_last_repotted"
 
 
 def _basic_schema(defaults: dict) -> vol.Schema:
@@ -71,6 +80,7 @@ def _features_schema(defaults: dict) -> vol.Schema:
         vol.Required(CONF_ENABLE_NOTES, default=defaults.get(CONF_ENABLE_NOTES, False)): selector.selector({"boolean": {}}),
         vol.Required(CONF_ENABLE_LATIN_NAME, default=defaults.get(CONF_ENABLE_LATIN_NAME, False)): selector.selector({"boolean": {}}),
         vol.Required(CONF_ENABLE_IMAGE, default=defaults.get(CONF_ENABLE_IMAGE, False)): selector.selector({"boolean": {}}),
+        vol.Required(CONF_ENABLE_REPOTTING, default=defaults.get(CONF_ENABLE_REPOTTING, False)): selector.selector({"boolean": {}}),
         vol.Optional(CONF_MOISTURE_SENSOR): selector.selector(
             {"entity": {"domain": "sensor", "multiple": False}}
         ),
@@ -118,6 +128,28 @@ def _last_fertilized_schema() -> vol.Schema:
 def _last_fertilized_custom_schema() -> vol.Schema:
     return vol.Schema({
         vol.Required("custom_fertilized_date"): selector.selector({"date": {}}),
+    })
+
+
+def _last_repotted_schema() -> vol.Schema:
+    return vol.Schema({
+        vol.Required(CONF_INITIAL_LAST_REPOTTED, default=WATERING_DATE_TODAY): selector.selector({
+            "select": {
+                "options": [
+                    {"value": WATERING_DATE_TODAY, "label": "Today"},
+                    {"value": WATERING_DATE_YESTERDAY, "label": "Yesterday"},
+                    {"value": WATERING_DATE_CUSTOM, "label": "Enter a custom date"},
+                    {"value": WATERING_DATE_NEVER, "label": "Haven't repotted yet"},
+                ],
+                "mode": "list",
+            }
+        }),
+    })
+
+
+def _last_repotted_custom_schema() -> vol.Schema:
+    return vol.Schema({
+        vol.Required("custom_repotted_date"): selector.selector({"date": {}}),
     })
 
 
@@ -231,6 +263,8 @@ class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _after_watering(self) -> FlowResult:
         if self._data.get(CONF_ENABLE_FERTILIZATION):
             return await self.async_step_fertilize()
+        if self._data.get(CONF_ENABLE_REPOTTING):
+            return await self.async_step_last_repotted()
         if self._data.get(CONF_ENABLE_LATIN_NAME):
             return await self.async_step_latin_name()
         if self._data.get(CONF_ENABLE_IMAGE):
@@ -273,6 +307,51 @@ class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="last_fertilized_custom", data_schema=_last_fertilized_custom_schema(), errors=errors)
 
     async def _after_fertilizing(self) -> FlowResult:
+        if self._data.get(CONF_ENABLE_REPOTTING):
+            return await self.async_step_last_repotted()
+        if self._data.get(CONF_ENABLE_LATIN_NAME):
+            return await self.async_step_latin_name()
+        if self._data.get(CONF_ENABLE_IMAGE):
+            return await self.async_step_image()
+        if self._data.get(CONF_MOISTURE_SENSOR):
+            return await self.async_step_moisture()
+        return self._create_entry()
+
+    async def async_step_last_repotted(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            selection = user_input[CONF_INITIAL_LAST_REPOTTED]
+            self._data[CONF_INITIAL_LAST_REPOTTED] = selection
+            if selection == WATERING_DATE_CUSTOM:
+                return await self.async_step_last_repotted_custom()
+            if selection != WATERING_DATE_NEVER:
+                today = date.today()
+                if selection == WATERING_DATE_TODAY:
+                    last = today
+                else:  # yesterday
+                    last = today - timedelta(days=1)
+                self._data[CONF_RESOLVED_LAST_REPOTTED] = last.isoformat()
+            # "never" → leave CONF_RESOLVED_LAST_REPOTTED absent
+            return await self._after_repotting()
+        return self.async_show_form(step_id="last_repotted", data_schema=_last_repotted_schema())
+
+    async def async_step_last_repotted_custom(self, user_input: dict | None = None) -> FlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            custom_date = user_input.get("custom_repotted_date", "")
+            try:
+                date.fromisoformat(custom_date)
+            except ValueError:
+                errors["custom_repotted_date"] = "invalid_date"
+            else:
+                self._data[CONF_RESOLVED_LAST_REPOTTED] = custom_date
+                return await self._after_repotting()
+        return self.async_show_form(
+            step_id="last_repotted_custom",
+            data_schema=_last_repotted_custom_schema(),
+            errors=errors,
+        )
+
+    async def _after_repotting(self) -> FlowResult:
         if self._data.get(CONF_ENABLE_LATIN_NAME):
             return await self.async_step_latin_name()
         if self._data.get(CONF_ENABLE_IMAGE):
@@ -341,6 +420,11 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
         self._config_entry = config_entry
         # Stash the moisture sensor choice from step 1 so step 2 knows what was picked
         self._pending_moisture_sensor: str | None = None
+        # Stash cleaned options while we run a sub-flow (fertilize/repot init)
+        self._pending_opts: dict = {}
+        # Flags set when a first-enable sub-flow is in progress
+        self._pending_fert_first: bool = False
+        self._pending_repot_first: bool = False
 
     async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
         errors: dict[str, str] = {}
@@ -360,6 +444,12 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
 
             # Notes enabled toggle — always write explicitly so falsy value persists
             cleaned[CONF_NOTES_ENABLED] = bool(user_input.get(CONF_NOTES_ENABLED, False))
+
+            # Fertilization enabled toggle — always write explicitly.
+            cleaned[CONF_FERTILIZATION_ENABLED] = bool(user_input.get(CONF_FERTILIZATION_ENABLED, False))
+
+            # Repotting enabled toggle — always write explicitly.
+            cleaned[CONF_REPOTTING_ENABLED] = bool(user_input.get(CONF_REPOTTING_ENABLED, False))
 
             # Latin name toggle — write explicitly, and handle the text field.
             latin_enabled = bool(user_input.get(CONF_ENABLE_LATIN_NAME, False))
@@ -393,10 +483,33 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     merged.pop(key, None)
                 # Also clear blanked fields — but skip keys we've already
                 # handled explicitly above (boolean toggles that are legitimately false)
-                _skip_clear = {CONF_NOTES_ENABLED, CONF_ENABLE_LATIN_NAME}
+                _skip_clear = {CONF_NOTES_ENABLED, CONF_ENABLE_LATIN_NAME, CONF_FERTILIZATION_ENABLED, CONF_REPOTTING_ENABLED}
                 for k, v in user_input.items():
                     if k not in _skip_clear and v in (None, "") and k in merged:
                         del merged[k]
+
+                # ── First-enable detection ────────────────────────────────────
+                # Fertilization: toggle just turned on AND no last_fertilized yet
+                fert_first_enable = (
+                    cleaned.get(CONF_FERTILIZATION_ENABLED) is True
+                    and STATE_LAST_FERTILIZED not in current_opts
+                )
+                # Repotting: toggle just turned on AND no last_repotted yet
+                repot_first_enable = (
+                    cleaned.get(CONF_REPOTTING_ENABLED) is True
+                    and STATE_LAST_REPOTTED not in current_opts
+                )
+
+                if fert_first_enable or repot_first_enable:
+                    # Stash the fully-merged options so the sub-flow can write
+                    # them once it has collected the missing dates.
+                    self._pending_opts = merged
+                    self._pending_fert_first = fert_first_enable
+                    self._pending_repot_first = repot_first_enable
+                    if fert_first_enable:
+                        return await self.async_step_fertilized_init()
+                    return await self.async_step_repotted_init()
+
                 return self.async_create_entry(title="", data=merged)
 
         defaults = {**entry.data, **current_opts}
@@ -426,11 +539,6 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             ),
         }
 
-        if entry.data.get(CONF_ENABLE_FERTILIZATION):
-            schema_fields[vol.Required(OPT_FERTILIZATION_INTERVAL, default=defaults.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL))] = selector.selector(
-                {"number": {"min": 1, "max": 365, "mode": "box", "unit_of_measurement": "days"}}
-            )
-
         if entry.data.get(CONF_ENABLE_IMAGE):
             schema_fields[vol.Optional(CONF_IMAGE_PATH, default=defaults.get(CONF_IMAGE_PATH, ""))] = selector.selector(
                 {"text": {}}
@@ -442,6 +550,28 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             current_opts.get(CONF_NOTES_ENABLED, entry.data.get(CONF_ENABLE_NOTES, False))
         )
         schema_fields[vol.Required(CONF_NOTES_ENABLED, default=notes_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+
+        # Fertilization toggle — always shown unconditionally so users can enable
+        # fertilization on plants that skipped it at setup.
+        fert_currently_enabled = bool(
+            current_opts.get(CONF_FERTILIZATION_ENABLED, entry.data.get(CONF_ENABLE_FERTILIZATION, False))
+        )
+        schema_fields[vol.Required(CONF_FERTILIZATION_ENABLED, default=fert_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+        # Only show the interval field when fertilization is currently active
+        if fert_currently_enabled:
+            schema_fields[vol.Required(OPT_FERTILIZATION_INTERVAL, default=defaults.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL))] = selector.selector(
+                {"number": {"min": 1, "max": 365, "mode": "box", "unit_of_measurement": "days"}}
+            )
+
+        # Repotting toggle — always shown unconditionally.
+        repotting_currently_enabled = bool(
+            current_opts.get(CONF_REPOTTING_ENABLED, entry.data.get(CONF_ENABLE_REPOTTING, False))
+        )
+        schema_fields[vol.Required(CONF_REPOTTING_ENABLED, default=repotting_currently_enabled)] = selector.selector(
             {"boolean": {}}
         )
 
@@ -503,5 +633,110 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
         return self.async_show_form(
             step_id="moisture_options",
             data_schema=_moisture_schema(defaults),
+            errors=errors,
+        )
+
+    # ── Fertilization first-enable sub-flow ───────────────────────────────────
+
+    async def async_step_fertilized_init(self, user_input: dict | None = None) -> FlowResult:
+        """Ask when the plant was last fertilized — shown only on first enable."""
+        if user_input is not None:
+            selection = user_input[CONF_INITIAL_LAST_FERTILIZED]
+            if selection == WATERING_DATE_CUSTOM:
+                return await self.async_step_fertilized_init_custom()
+            if selection != WATERING_DATE_NEVER:
+                today = date.today()
+                if selection == WATERING_DATE_TODAY:
+                    last = today
+                else:  # yesterday
+                    last = today - timedelta(days=1)
+                interval = int(
+                    self._pending_opts.get(
+                        OPT_FERTILIZATION_INTERVAL,
+                        self._config_entry.options.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL),
+                    )
+                )
+                self._pending_opts[STATE_LAST_FERTILIZED] = last.isoformat()
+                self._pending_opts[STATE_NEXT_FERTILIZED] = (last + timedelta(days=interval)).isoformat()
+            else:
+                # "never" — strip any stale dates that may have been carried into merged
+                self._pending_opts.pop(STATE_LAST_FERTILIZED, None)
+                self._pending_opts.pop(STATE_NEXT_FERTILIZED, None)
+            return await self._after_fertilized_init()
+        return self.async_show_form(
+            step_id="fertilized_init",
+            data_schema=_last_fertilized_schema(),
+        )
+
+    async def async_step_fertilized_init_custom(self, user_input: dict | None = None) -> FlowResult:
+        """Custom date entry for fertilization first-enable."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            custom_date = user_input.get("custom_fertilized_date", "")
+            try:
+                last = date.fromisoformat(custom_date)
+            except ValueError:
+                errors["custom_fertilized_date"] = "invalid_date"
+            else:
+                interval = int(
+                    self._pending_opts.get(
+                        OPT_FERTILIZATION_INTERVAL,
+                        self._config_entry.options.get(OPT_FERTILIZATION_INTERVAL, DEFAULT_FERTILIZATION_INTERVAL),
+                    )
+                )
+                self._pending_opts[STATE_LAST_FERTILIZED] = last.isoformat()
+                self._pending_opts[STATE_NEXT_FERTILIZED] = (last + timedelta(days=interval)).isoformat()
+                return await self._after_fertilized_init()
+        return self.async_show_form(
+            step_id="fertilized_init_custom",
+            data_schema=_last_fertilized_custom_schema(),
+            errors=errors,
+        )
+
+    async def _after_fertilized_init(self) -> FlowResult:
+        """Route to repotting first-enable if also needed, otherwise save."""
+        if self._pending_repot_first:
+            return await self.async_step_repotted_init()
+        return self.async_create_entry(title="", data=self._pending_opts)
+
+    # ── Repotting first-enable sub-flow ───────────────────────────────────────
+
+    async def async_step_repotted_init(self, user_input: dict | None = None) -> FlowResult:
+        """Ask when the plant was last repotted — shown only on first enable."""
+        if user_input is not None:
+            selection = user_input[CONF_INITIAL_LAST_REPOTTED]
+            if selection == WATERING_DATE_CUSTOM:
+                return await self.async_step_repotted_init_custom()
+            if selection != WATERING_DATE_NEVER:
+                today = date.today()
+                if selection == WATERING_DATE_TODAY:
+                    last = today
+                else:  # yesterday
+                    last = today - timedelta(days=1)
+                self._pending_opts[STATE_LAST_REPOTTED] = last.isoformat()
+            else:
+                # "never" — strip any stale date that may have been carried into merged
+                self._pending_opts.pop(STATE_LAST_REPOTTED, None)
+            return self.async_create_entry(title="", data=self._pending_opts)
+        return self.async_show_form(
+            step_id="repotted_init",
+            data_schema=_last_repotted_schema(),
+        )
+
+    async def async_step_repotted_init_custom(self, user_input: dict | None = None) -> FlowResult:
+        """Custom date entry for repotting first-enable."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            custom_date = user_input.get("custom_repotted_date", "")
+            try:
+                date.fromisoformat(custom_date)
+            except ValueError:
+                errors["custom_repotted_date"] = "invalid_date"
+            else:
+                self._pending_opts[STATE_LAST_REPOTTED] = custom_date
+                return self.async_create_entry(title="", data=self._pending_opts)
+        return self.async_show_form(
+            step_id="repotted_init_custom",
+            data_schema=_last_repotted_custom_schema(),
             errors=errors,
         )

--- a/custom_components/adaptive_plant/const.py
+++ b/custom_components/adaptive_plant/const.py
@@ -16,6 +16,9 @@ CONF_MOISTURE_SENSOR = "moisture_sensor"
 CONF_DRY_THRESHOLD = "dry_threshold"
 CONF_WET_THRESHOLD = "wet_threshold"
 CONF_LABEL = "label"
+CONF_ENABLE_LATIN_NAME = "enable_latin_name"
+CONF_LATIN_NAME = "latin_name"
+CONF_NOTES_ENABLED = "notes_enabled"
 
 # ── Config entry options keys (mutable at runtime) ─────────────────────────────
 OPT_WATERING_INTERVAL = "watering_interval_days"

--- a/custom_components/adaptive_plant/const.py
+++ b/custom_components/adaptive_plant/const.py
@@ -19,10 +19,13 @@ CONF_LABEL = "label"
 CONF_ENABLE_LATIN_NAME = "enable_latin_name"
 CONF_LATIN_NAME = "latin_name"
 CONF_NOTES_ENABLED = "notes_enabled"
+CONF_ENABLE_REPOTTING = "enable_repotting"
 
 # ── Config entry options keys (mutable at runtime) ─────────────────────────────
 OPT_WATERING_INTERVAL = "watering_interval_days"
 OPT_FERTILIZATION_INTERVAL = "fertilization_interval_days"
+CONF_FERTILIZATION_ENABLED = "fertilization_enabled"
+CONF_REPOTTING_ENABLED = "repotting_enabled"
 
 # ── State keys (stored in config entry options) ────────────────────────────────
 STATE_LAST_WATERED = "last_watered"
@@ -33,6 +36,11 @@ STATE_HEALTH_LAST_UPDATED = "health_last_updated"
 STATE_LAST_FERTILIZED = "last_fertilized"
 STATE_NEXT_FERTILIZED = "next_fertilized"
 STATE_NOTES = "notes"
+STATE_LAST_REPOTTED = "last_repotted"
+STATE_REPOTTED_DATE_INPUT = "repotted_date_input"
+
+# ── Setup-wizard resolved keys (stored in entry.data, seeded to options) ──────
+CONF_RESOLVED_LAST_REPOTTED = "_resolved_last_repotted"
 
 # ── Health select options ──────────────────────────────────────────────────────
 HEALTH_OPTIONS = ["excellent", "good", "poor", "sick"]

--- a/custom_components/adaptive_plant/manifest.json
+++ b/custom_components/adaptive_plant/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/Big-Xan/adaptive_plant/issues",
   "quality_scale": "custom",
   "requirements": [],
-  "version": "1.0.10"
+  "version": "1.0.11"
 }

--- a/custom_components/adaptive_plant/manifest.json
+++ b/custom_components/adaptive_plant/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/Big-Xan/adaptive_plant/issues",
   "quality_scale": "custom",
   "requirements": [],
-  "version": "1.0.11"
+  "version": "1.1.0"
 }

--- a/custom_components/adaptive_plant/number.py
+++ b/custom_components/adaptive_plant/number.py
@@ -18,10 +18,10 @@ async def async_setup_entry(
 ) -> None:
     plant: PlantData = hass.data[DOMAIN][entry.entry_id]
 
-    entities: list[PlantNumberBase] = [WateringIntervalNumber(plant, entry)]
-
-    if plant.enable_fertilization:
-        entities.append(FertilizationIntervalNumber(plant, entry))
+    entities: list[PlantNumberBase] = [
+        WateringIntervalNumber(plant, entry),
+        FertilizationIntervalNumber(plant, entry),
+    ]
 
     async_add_entities(entities)
 
@@ -91,6 +91,10 @@ class FertilizationIntervalNumber(PlantNumberBase):
     def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
         super().__init__(plant, entry)
         self._attr_unique_id = f"{entry.entry_id}_fertilization_interval"
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_fertilization
 
     @property
     def native_value(self) -> float:

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -20,11 +20,14 @@ from .const import (
     CONF_EARLY_WATERING_THRESHOLD,
     CONF_ENABLE_FERTILIZATION,
     CONF_ENABLE_IMAGE,
+    CONF_ENABLE_LATIN_NAME,
     CONF_ENABLE_NOTES,
     CONF_HEALTH_PROMPT_INTERVAL,
     CONF_IMAGE_PATH,
     CONF_LABEL,
+    CONF_LATIN_NAME,
     CONF_MOISTURE_SENSOR,
+    CONF_NOTES_ENABLED,
     CONF_PLANT_NAME,
     CONF_SNOOZE_THRESHOLD,
     CONF_WET_THRESHOLD,
@@ -107,7 +110,20 @@ class PlantData:
 
     @property
     def enable_notes(self) -> bool:
+        # Options override takes precedence — allows toggling after setup.
+        # Falls back to the original entry.data value set during setup.
+        if CONF_NOTES_ENABLED in self._entry.options:
+            return bool(self._entry.options[CONF_NOTES_ENABLED])
         return bool(self._entry.data.get(CONF_ENABLE_NOTES, False))
+
+    @property
+    def enable_latin_name(self) -> bool:
+        return bool(self._entry.data.get(CONF_ENABLE_LATIN_NAME, False))
+
+    @property
+    def latin_name(self) -> str | None:
+        val = self._entry.options.get(CONF_LATIN_NAME) or self._entry.data.get(CONF_LATIN_NAME)
+        return val.strip() if val and val.strip() else None
 
     @property
     def enable_image(self) -> bool:
@@ -423,6 +439,9 @@ class PlantData:
 
     async def set_notes(self, value: str) -> None:
         await self._persist({STATE_NOTES: value})
+
+    async def set_latin_name(self, value: str) -> None:
+        await self._persist({CONF_LATIN_NAME: value.strip() or ""})
 
     # ── Event-driven callbacks ───────────────────────────────────────────────────
 

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -118,11 +118,19 @@ class PlantData:
 
     @property
     def enable_latin_name(self) -> bool:
+        # Options override takes precedence — allows enabling after setup.
+        if CONF_ENABLE_LATIN_NAME in self._entry.options:
+            return bool(self._entry.options[CONF_ENABLE_LATIN_NAME])
         return bool(self._entry.data.get(CONF_ENABLE_LATIN_NAME, False))
 
     @property
     def latin_name(self) -> str | None:
-        val = self._entry.options.get(CONF_LATIN_NAME) or self._entry.data.get(CONF_LATIN_NAME)
+        # Check options first using key presence — an empty string in options
+        # means the user intentionally cleared it, so don't fall back to entry.data.
+        if CONF_LATIN_NAME in self._entry.options:
+            val = self._entry.options[CONF_LATIN_NAME]
+            return val.strip() if val and val.strip() else None
+        val = self._entry.data.get(CONF_LATIN_NAME)
         return val.strip() if val and val.strip() else None
 
     @property

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -22,6 +22,8 @@ from .const import (
     CONF_ENABLE_IMAGE,
     CONF_ENABLE_LATIN_NAME,
     CONF_ENABLE_NOTES,
+    CONF_ENABLE_REPOTTING,
+    CONF_FERTILIZATION_ENABLED,
     CONF_HEALTH_PROMPT_INTERVAL,
     CONF_IMAGE_PATH,
     CONF_LABEL,
@@ -29,6 +31,7 @@ from .const import (
     CONF_MOISTURE_SENSOR,
     CONF_NOTES_ENABLED,
     CONF_PLANT_NAME,
+    CONF_REPOTTING_ENABLED,
     CONF_SNOOZE_THRESHOLD,
     CONF_WET_THRESHOLD,
     DEFAULT_EARLY_WATERING_THRESHOLD,
@@ -46,6 +49,8 @@ from .const import (
     STATE_HEALTH,
     STATE_HEALTH_LAST_UPDATED,
     STATE_LAST_FERTILIZED,
+    STATE_LAST_REPOTTED,
+    STATE_REPOTTED_DATE_INPUT,
     STATE_LAST_WATERED,
     STATE_NEXT_FERTILIZED,
     STATE_NEXT_WATERING,
@@ -106,6 +111,10 @@ class PlantData:
 
     @property
     def enable_fertilization(self) -> bool:
+        # Options override takes precedence — allows toggling after setup
+        # (including enabling it on plants where it was skipped at setup).
+        if CONF_FERTILIZATION_ENABLED in self._entry.options:
+            return bool(self._entry.options[CONF_FERTILIZATION_ENABLED])
         return bool(self._entry.data.get(CONF_ENABLE_FERTILIZATION, False))
 
     @property
@@ -122,6 +131,13 @@ class PlantData:
         if CONF_ENABLE_LATIN_NAME in self._entry.options:
             return bool(self._entry.options[CONF_ENABLE_LATIN_NAME])
         return bool(self._entry.data.get(CONF_ENABLE_LATIN_NAME, False))
+
+    @property
+    def enable_repotting(self) -> bool:
+        # Options override takes precedence — allows toggling after setup.
+        if CONF_REPOTTING_ENABLED in self._entry.options:
+            return bool(self._entry.options[CONF_REPOTTING_ENABLED])
+        return bool(self._entry.data.get(CONF_ENABLE_REPOTTING, False))
 
     @property
     def latin_name(self) -> str | None:
@@ -238,6 +254,15 @@ class PlantData:
     @property
     def notes(self) -> str:
         return self._entry.options.get(STATE_NOTES, "")
+
+    @property
+    def last_repotted(self) -> str | None:
+        return self._entry.options.get(STATE_LAST_REPOTTED)
+
+    @property
+    def repotted_date_input(self) -> str:
+        """The user-editable date correction field. Empty string when not set."""
+        return self._entry.options.get(STATE_REPOTTED_DATE_INPUT, "")
 
     # ── Computed ─────────────────────────────────────────────────────────────────
 
@@ -450,6 +475,40 @@ class PlantData:
 
     async def set_latin_name(self, value: str) -> None:
         await self._persist({CONF_LATIN_NAME: value.strip() or ""})
+
+    # ── Repotting ─────────────────────────────────────────────────────────────
+
+    async def mark_repotted(self) -> None:
+        """Stamp the repotting date.
+
+        Uses the value of the repotted_date_input text entity if it contains a
+        valid ISO date, otherwise falls back to today. Clears the input field
+        after stamping so it doesn't linger as a stale suggestion.
+        """
+        today = date.today()
+        raw = self.repotted_date_input.strip()
+        stamp: str
+        if raw:
+            try:
+                date.fromisoformat(raw)   # validate
+                stamp = raw
+            except ValueError:
+                _LOGGER.warning(
+                    "%s: repotted_date_input '%s' is not a valid ISO date — using today",
+                    self.plant_name, raw,
+                )
+                stamp = today.isoformat()
+        else:
+            stamp = today.isoformat()
+
+        await self._persist({
+            STATE_LAST_REPOTTED: stamp,
+            STATE_REPOTTED_DATE_INPUT: "",   # clear the correction field
+        })
+
+    async def set_repotted_date_input(self, value: str) -> None:
+        """Store a prospective repotting date typed by the user."""
+        await self._persist({STATE_REPOTTED_DATE_INPUT: value.strip()})
 
     # ── Event-driven callbacks ───────────────────────────────────────────────────
 

--- a/custom_components/adaptive_plant/sensor.py
+++ b/custom_components/adaptive_plant/sensor.py
@@ -28,14 +28,13 @@ async def async_setup_entry(
         EarlyWateringCountSensor(plant, entry),
         SnoozeCountSensor(plant, entry),
         CurrentMoistureSensor(plant, entry),
+        LastFertilizedSensor(plant, entry),
+        NextFertilizedSensor(plant, entry),
+        DaysUntilFertilizingSensor(plant, entry),
     ]
 
-    if plant.enable_fertilization:
-        entities += [
-            LastFertilizedSensor(plant, entry),
-            NextFertilizedSensor(plant, entry),
-            DaysUntilFertilizingSensor(plant, entry),
-        ]
+    if plant.enable_repotting:
+        entities.append(LastRepottedSensor(plant, entry))
 
     async_add_entities(entities)
 
@@ -190,6 +189,10 @@ class LastFertilizedSensor(PlantSensorBase):
         self._attr_unique_id = f"{entry.entry_id}_last_fertilized"
 
     @property
+    def available(self) -> bool:
+        return self._plant.enable_fertilization
+
+    @property
     def native_value(self) -> date | None:
         val = self._plant.last_fertilized
         if val:
@@ -209,6 +212,10 @@ class NextFertilizedSensor(PlantSensorBase):
         self._attr_unique_id = f"{entry.entry_id}_next_fertilized"
 
     @property
+    def available(self) -> bool:
+        return self._plant.enable_fertilization
+
+    @property
     def native_value(self) -> date | None:
         val = self._plant.next_fertilized
         if val:
@@ -226,6 +233,10 @@ class DaysUntilFertilizingSensor(PlantSensorBase):
     def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
         super().__init__(plant, entry)
         self._attr_unique_id = f"{entry.entry_id}_days_until_fertilizing"
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_fertilization
 
     @property
     def native_value(self) -> str | None:
@@ -305,3 +316,29 @@ class CurrentMoistureSensor(PlantSensorBase):
             return False
         state = self._plant._hass.states.get(sensor_id)
         return state is not None and state.state not in ("unknown", "unavailable")
+
+
+class LastRepottedSensor(PlantSensorBase):
+    """Date sensor recording the last time this plant was repotted."""
+
+    _attr_device_class = SensorDeviceClass.DATE
+    _attr_translation_key = "last_repotted"
+    _attr_icon = "mdi:pot-mix"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        super().__init__(plant, entry)
+        self._attr_unique_id = f"{entry.entry_id}_last_repotted"
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_repotting
+
+    @property
+    def native_value(self) -> date | None:
+        val = self._plant.last_repotted
+        if val:
+            try:
+                return date.fromisoformat(val)
+            except ValueError:
+                return None
+        return None

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -81,6 +81,13 @@
           "image_path": "Image path (/local/...)"
         }
       },
+      "latin_name": {
+        "title": "Latin Name",
+        "description": "Enter the scientific name for this plant (e.g. Monstera deliciosa). Leave blank to skip.",
+        "data": {
+          "latin_name": "Latin name"
+        }
+      },
       "moisture": {
         "title": "Moisture Thresholds",
         "description": "Set the thresholds for dry and wet moisture readings.",
@@ -114,6 +121,7 @@
           "image_path": "Image path (/local/...)",
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
+          "enable_latin_name": "Enable latin name",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -7,6 +7,7 @@
         "description": "Set up basic care settings for your plant.",
         "data": {
           "plant_name": "Plant name",
+          "latin_name": "Latin name (optional)",
           "area": "Area",
           "label": "Location label (optional)",
           "watering_interval_days": "Watering interval (days)",
@@ -16,6 +17,7 @@
         },
         "data_description": {
           "plant_name": "A friendly name for this plant.",
+          "latin_name": "Optional scientific name for this plant (e.g. Monstera deliciosa).",
           "area": "Assign this plant to a Home Assistant area.",
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank if not needed.",
           "watering_interval_days": "How many days between waterings.",
@@ -30,6 +32,7 @@
         "data": {
           "enable_fertilization": "Track fertilization",
           "enable_notes": "Add a notes field",
+          "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
           "moisture_sensor": "Moisture sensor (optional)"
         },
@@ -109,11 +112,14 @@
           "health_prompt_interval_days": "Health prompt interval (days)",
           "fertilization_interval_days": "Fertilization interval (days)",
           "image_path": "Image path (/local/...)",
+          "notes_enabled": "Enable notes",
+          "latin_name": "Latin name",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank to remove.",
+          "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic."
         }
@@ -165,7 +171,8 @@
       }
     },
     "text": {
-      "notes": { "name": "Notes" }
+      "notes": { "name": "Notes" },
+      "latin_name": { "name": "Latin name" }
     }
   }
 }

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -34,6 +34,7 @@
           "enable_notes": "Add a notes field",
           "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
+          "enable_repotting": "Track repotting",
           "moisture_sensor": "Moisture sensor (optional)"
         },
         "data_description": {
@@ -72,6 +73,20 @@
         "description": "Enter the date you last fertilized this plant.",
         "data": {
           "custom_fertilized_date": "Date last fertilized"
+        }
+      },
+      "last_repotted": {
+        "title": "Last Repotting",
+        "description": "When did you last repot this plant?",
+        "data": {
+          "initial_last_repotted": "Last repotted"
+        }
+      },
+      "last_repotted_custom": {
+        "title": "Last Repotting - Custom Date",
+        "description": "Enter the date you last repotted this plant.",
+        "data": {
+          "custom_repotted_date": "Date last repotted"
         }
       },
       "image": {
@@ -122,12 +137,16 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "fertilization_enabled": "Enable fertilization tracking",
+          "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank to remove.",
           "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
+          "fertilization_enabled": "Toggle to enable or disable fertilization tracking. Previous dates are preserved when re-enabled.",
+          "repotting_enabled": "Toggle to enable or disable repotting tracking. Previous dates are preserved when re-enabled.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic."
         }
@@ -139,10 +158,39 @@
           "dry_threshold": "Dry threshold (reschedule watering to today)",
           "wet_threshold": "Wet threshold (auto-mark as watered)"
         }
+      },
+      "fertilized_init": {
+        "title": "Last Fertilization",
+        "description": "When did you last fertilize this plant?",
+        "data": {
+          "initial_last_fertilized": "Last fertilized"
+        }
+      },
+      "fertilized_init_custom": {
+        "title": "Last Fertilization - Custom Date",
+        "description": "Enter the date you last fertilized this plant.",
+        "data": {
+          "custom_fertilized_date": "Date last fertilized"
+        }
+      },
+      "repotted_init": {
+        "title": "Last Repotting",
+        "description": "When did you last repot this plant?",
+        "data": {
+          "initial_last_repotted": "Last repotted"
+        }
+      },
+      "repotted_init_custom": {
+        "title": "Last Repotting - Custom Date",
+        "description": "Enter the date you last repotted this plant.",
+        "data": {
+          "custom_repotted_date": "Date last repotted"
+        }
       }
     },
     "error": {
-      "dry_above_wet": "Dry threshold must be less than wet threshold."
+      "dry_above_wet": "Dry threshold must be less than wet threshold.",
+      "invalid_date": "Please enter a valid date."
     }
   },
   "entity": {
@@ -155,13 +203,15 @@
       "last_fertilized": { "name": "Last fertilized" },
       "next_fertilized": { "name": "Next fertilization" },
       "days_until_fertilizing": { "name": "Days until fertilization" },
-      "current_moisture": { "name": "Soil moisture" }
+      "current_moisture": { "name": "Soil moisture" },
+      "last_repotted": { "name": "Last repotted" }
     },
     "button": {
       "mark_watered": { "name": "Mark watered" },
       "snooze_watering": { "name": "Snooze today's tasks" },
       "mark_fertilized": { "name": "Mark fertilized" },
-      "confirm_health": { "name": "Confirm health" }
+      "confirm_health": { "name": "Confirm health" },
+      "mark_repotted": { "name": "Mark repotted" }
     },
     "number": {
       "watering_interval_days": { "name": "Watering interval" },
@@ -180,7 +230,8 @@
     },
     "text": {
       "notes": { "name": "Notes" },
-      "latin_name": { "name": "Latin name" }
+      "latin_name": { "name": "Latin name" },
+      "repotted_date_input": { "name": "Repotted on" }
     }
   }
 }

--- a/custom_components/adaptive_plant/text.py
+++ b/custom_components/adaptive_plant/text.py
@@ -1,4 +1,4 @@
-"""Text entity for free-form plant notes."""
+"""Text entity for free-form plant notes and latin name."""
 from __future__ import annotations
 
 from homeassistant.components.text import TextEntity, TextMode
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import CONF_LATIN_NAME, DOMAIN, STATE_NOTES
 from .plant import PlantData
 
 
@@ -17,8 +17,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     plant: PlantData = hass.data[DOMAIN][entry.entry_id]
+    entities = []
     if plant.enable_notes:
-        async_add_entities([NotesText(plant, entry)])
+        entities.append(NotesText(plant, entry))
+    if plant.enable_latin_name:
+        entities.append(LatinNameText(plant, entry))
+    if entities:
+        async_add_entities(entities)
 
 
 class NotesText(TextEntity):
@@ -29,7 +34,7 @@ class NotesText(TextEntity):
     _attr_translation_key = "notes"
     _attr_mode = TextMode.TEXT
     _attr_native_min = 0
-    _attr_native_max = 255
+    _attr_native_max = 1000
     _attr_icon = "mdi:note-text"
 
     def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
@@ -62,3 +67,46 @@ class NotesText(TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         await self._plant.set_notes(value)
+
+
+class LatinNameText(TextEntity):
+    """Text entity for storing and editing the plant's latin name."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "latin_name"
+    _attr_mode = TextMode.TEXT
+    _attr_native_min = 0
+    _attr_native_max = 255
+    _attr_icon = "mdi:flower-outline"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        self._plant = plant
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_latin_name"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._plant.plant_name,
+            manufacturer="Adaptive Plant",
+            model="Plant Monitor",
+        )
+
+    @property
+    def native_value(self) -> str:
+        return self._plant.latin_name or ""
+
+    async def async_added_to_hass(self) -> None:
+        self._plant.add_listener(self._on_plant_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._plant.remove_listener(self._on_plant_update)
+
+    @callback
+    def _on_plant_update(self) -> None:
+        self.async_write_ha_state()
+
+    async def async_set_value(self, value: str) -> None:
+        await self._plant.set_latin_name(value)

--- a/custom_components/adaptive_plant/text.py
+++ b/custom_components/adaptive_plant/text.py
@@ -34,7 +34,7 @@ class NotesText(TextEntity):
     _attr_translation_key = "notes"
     _attr_mode = TextMode.TEXT
     _attr_native_min = 0
-    _attr_native_max = 1000
+    _attr_native_max = 255
     _attr_icon = "mdi:note-text"
 
     def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
@@ -50,6 +50,10 @@ class NotesText(TextEntity):
             manufacturer="Adaptive Plant",
             model="Plant Monitor",
         )
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_notes
 
     @property
     def native_value(self) -> str:
@@ -93,6 +97,10 @@ class LatinNameText(TextEntity):
             manufacturer="Adaptive Plant",
             model="Plant Monitor",
         )
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_latin_name
 
     @property
     def native_value(self) -> str:

--- a/custom_components/adaptive_plant/text.py
+++ b/custom_components/adaptive_plant/text.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_LATIN_NAME, DOMAIN, STATE_NOTES
+from .const import CONF_LATIN_NAME, DOMAIN, STATE_NOTES, STATE_REPOTTED_DATE_INPUT
 from .plant import PlantData
 
 
@@ -22,6 +22,8 @@ async def async_setup_entry(
         entities.append(NotesText(plant, entry))
     if plant.enable_latin_name:
         entities.append(LatinNameText(plant, entry))
+    if plant.enable_repotting:
+        entities.append(RepottedDateInputText(plant, entry))
     if entities:
         async_add_entities(entities)
 
@@ -118,3 +120,55 @@ class LatinNameText(TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         await self._plant.set_latin_name(value)
+
+
+class RepottedDateInputText(TextEntity):
+    """Text entity for entering a custom repotting date (YYYY-MM-DD).
+
+    Normally left blank. If the user types a date here before pressing
+    'Mark repotted', that date is used instead of today. The field is
+    automatically cleared after the button is pressed.
+    """
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_translation_key = "repotted_date_input"
+    _attr_mode = TextMode.TEXT
+    _attr_native_min = 0
+    _attr_native_max = 10          # YYYY-MM-DD is exactly 10 chars
+    _attr_icon = "mdi:calendar-edit"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        self._plant = plant
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_repotted_date_input"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._plant.plant_name,
+            manufacturer="Adaptive Plant",
+            model="Plant Monitor",
+        )
+
+    @property
+    def available(self) -> bool:
+        return self._plant.enable_repotting
+
+    @property
+    def native_value(self) -> str:
+        return self._plant.repotted_date_input
+
+    async def async_added_to_hass(self) -> None:
+        self._plant.add_listener(self._on_plant_update)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._plant.remove_listener(self._on_plant_update)
+
+    @callback
+    def _on_plant_update(self) -> None:
+        self.async_write_ha_state()
+
+    async def async_set_value(self, value: str) -> None:
+        await self._plant.set_repotted_date_input(value)

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -81,6 +81,13 @@
           "image_path": "Image path (/local/...)"
         }
       },
+      "latin_name": {
+        "title": "Latin Name",
+        "description": "Enter the scientific name for this plant (e.g. Monstera deliciosa). Leave blank to skip.",
+        "data": {
+          "latin_name": "Latin name"
+        }
+      },
       "moisture": {
         "title": "Moisture Thresholds",
         "description": "Set the thresholds for dry and wet moisture readings.",
@@ -114,6 +121,7 @@
           "image_path": "Image path (/local/...)",
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
+          "enable_latin_name": "Enable latin name",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -7,6 +7,7 @@
         "description": "Set up basic care settings for your plant.",
         "data": {
           "plant_name": "Plant name",
+          "latin_name": "Latin name (optional)",
           "area": "Area",
           "label": "Location label (optional)",
           "watering_interval_days": "Watering interval (days)",
@@ -16,6 +17,7 @@
         },
         "data_description": {
           "plant_name": "A friendly name for this plant.",
+          "latin_name": "Optional scientific name for this plant (e.g. Monstera deliciosa).",
           "area": "Assign this plant to a Home Assistant area.",
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank if not needed.",
           "watering_interval_days": "How many days between waterings.",
@@ -30,6 +32,7 @@
         "data": {
           "enable_fertilization": "Track fertilization",
           "enable_notes": "Add a notes field",
+          "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
           "moisture_sensor": "Moisture sensor (optional)"
         },
@@ -109,11 +112,14 @@
           "health_prompt_interval_days": "Health prompt interval (days)",
           "fertilization_interval_days": "Fertilization interval (days)",
           "image_path": "Image path (/local/...)",
+          "notes_enabled": "Enable notes",
+          "latin_name": "Latin name",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank to remove.",
+          "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic."
         }
@@ -165,7 +171,8 @@
       }
     },
     "text": {
-      "notes": { "name": "Notes" }
+      "notes": { "name": "Notes" },
+      "latin_name": { "name": "Latin name" }
     }
   }
 }

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -34,6 +34,7 @@
           "enable_notes": "Add a notes field",
           "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
+          "enable_repotting": "Track repotting",
           "moisture_sensor": "Moisture sensor (optional)"
         },
         "data_description": {
@@ -72,6 +73,20 @@
         "description": "Enter the date you last fertilized this plant.",
         "data": {
           "custom_fertilized_date": "Date last fertilized"
+        }
+      },
+      "last_repotted": {
+        "title": "Last Repotting",
+        "description": "When did you last repot this plant?",
+        "data": {
+          "initial_last_repotted": "Last repotted"
+        }
+      },
+      "last_repotted_custom": {
+        "title": "Last Repotting - Custom Date",
+        "description": "Enter the date you last repotted this plant.",
+        "data": {
+          "custom_repotted_date": "Date last repotted"
         }
       },
       "image": {
@@ -122,12 +137,16 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "fertilization_enabled": "Enable fertilization tracking",
+          "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank to remove.",
           "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
+          "fertilization_enabled": "Toggle to enable or disable fertilization tracking. Previous dates are preserved when re-enabled.",
+          "repotting_enabled": "Toggle to enable or disable repotting tracking. Previous dates are preserved when re-enabled.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic."
         }
@@ -139,10 +158,39 @@
           "dry_threshold": "Dry threshold (reschedule watering to today)",
           "wet_threshold": "Wet threshold (auto-mark as watered)"
         }
+      },
+      "fertilized_init": {
+        "title": "Last Fertilization",
+        "description": "When did you last fertilize this plant?",
+        "data": {
+          "initial_last_fertilized": "Last fertilized"
+        }
+      },
+      "fertilized_init_custom": {
+        "title": "Last Fertilization - Custom Date",
+        "description": "Enter the date you last fertilized this plant.",
+        "data": {
+          "custom_fertilized_date": "Date last fertilized"
+        }
+      },
+      "repotted_init": {
+        "title": "Last Repotting",
+        "description": "When did you last repot this plant?",
+        "data": {
+          "initial_last_repotted": "Last repotted"
+        }
+      },
+      "repotted_init_custom": {
+        "title": "Last Repotting - Custom Date",
+        "description": "Enter the date you last repotted this plant.",
+        "data": {
+          "custom_repotted_date": "Date last repotted"
+        }
       }
     },
     "error": {
-      "dry_above_wet": "Dry threshold must be less than wet threshold."
+      "dry_above_wet": "Dry threshold must be less than wet threshold.",
+      "invalid_date": "Please enter a valid date."
     }
   },
   "entity": {
@@ -155,13 +203,15 @@
       "last_fertilized": { "name": "Last fertilized" },
       "next_fertilized": { "name": "Next fertilization" },
       "days_until_fertilizing": { "name": "Days until fertilization" },
-      "current_moisture": { "name": "Soil moisture" }
+      "current_moisture": { "name": "Soil moisture" },
+      "last_repotted": { "name": "Last repotted" }
     },
     "button": {
       "mark_watered": { "name": "Mark watered" },
       "snooze_watering": { "name": "Snooze today's tasks" },
       "mark_fertilized": { "name": "Mark fertilized" },
-      "confirm_health": { "name": "Confirm health" }
+      "confirm_health": { "name": "Confirm health" },
+      "mark_repotted": { "name": "Mark repotted" }
     },
     "number": {
       "watering_interval_days": { "name": "Watering interval" },
@@ -180,7 +230,8 @@
     },
     "text": {
       "notes": { "name": "Notes" },
-      "latin_name": { "name": "Latin name" }
+      "latin_name": { "name": "Latin name" },
+      "repotted_date_input": { "name": "Repotted on" }
     }
   }
 }

--- a/www/adaptive-plant-card.js
+++ b/www/adaptive-plant-card.js
@@ -1,4 +1,4 @@
-// Adaptive Plant Card v13
+// Adaptive Plant Card v14
 
 class AdaptivePlantCard extends HTMLElement {
   constructor() {
@@ -37,6 +37,17 @@ class AdaptivePlantCard extends HTMLElement {
     // v13 options
     this._excludeMoistureFromUpcoming = config.exclude_moisture_from_upcoming === true;
     this._showMoistureInOverview      = config.show_moisture_in_overview      === true;
+
+    // v15 options
+    this._showRepotting       = config.show_repotting       !== false;
+    this._repottedButtonColor = config.repotted_button_color || '#c8975a';
+    this._repottedButtonIcon  = config.repotted_button_icon  || null;
+    this._showLatinName       = config.show_latin_name       === true;
+    this._latinNameSize       = (config.latin_name_size !== undefined && config.latin_name_size !== null && config.latin_name_size !== '')
+                                  ? config.latin_name_size : null;
+    this._latinNameColor      = config.latin_name_color  || null;
+    this._latinNamePadding    = (config.latin_name_padding !== undefined && config.latin_name_padding !== null && config.latin_name_padding !== '')
+                                  ? config.latin_name_padding : null;
 
     var ic = config.icons || {};
     this._icons = {
@@ -122,6 +133,39 @@ class AdaptivePlantCard extends HTMLElement {
       return '<ha-icon icon="' + value + '" style="--mdc-icon-size:' + size + ';color:' + color + ';display:inline-flex;align-items:center;"></ha-icon>';
     }
     return '<span class="emoji-icon">' + value + '</span>';
+  }
+
+  // ── Latin / scientific name line rendered below the plant name ────────────
+  _latinNameHtml(p) {
+    if (!this._showLatinName || !p.latinName) return '';
+    var size  = this._latinNameSize    ? this._latinNameSize    + 'px' : '11px';
+    var color = this._latinNameColor   ? this._latinNameColor          : 'var(--secondary-text-color,#888)';
+    var vpad  = this._latinNamePadding ? this._latinNamePadding + 'px' : '1px';
+    return '<div class="plant-latin" style="font-size:' + size + ';color:' + color + ';padding-top:' + vpad + ';padding-bottom:' + vpad + ';">' + p.latinName + '</div>';
+  }
+
+  // ── Mark Repotted detail-action button ────────────────────────────────────
+  _repottedBtn(p) {
+    var color = this._repottedButtonColor;
+    var icon  = this._repottedButtonIcon
+      ? this._renderIcon(this._repottedButtonIcon, color, '15px') + ' '
+      : '';
+    return '<button class="detail-btn btn-repotted" style="color:' + color + ';background:' + color + '26;"' +
+      ' data-repotted-entity="' + p.repottedDateInputId + '"' +
+      ' data-repotted-btn="' + p.btnRepotted + '"' +
+      ' data-plant-id="' + p.id + '">' +
+      icon + 'Mark Repotted' +
+    '</button>';
+  }
+
+  // ── Moisture pill for overview meta row ───────────────────────────────────
+  _moisturePill(p) {
+    var pct   = Math.round(p.moistureVal);
+    var color = '#64b4ff';
+    return '<span class="meta-item moisture-pill">' +
+      this._renderIcon(this._icons.water, color, '12px') +
+      ' <span style="color:' + color + ';font-weight:600;">' + pct + '%</span>' +
+    '</span>';
   }
 
   _bootstrapShell() {
@@ -234,6 +278,15 @@ class AdaptivePlantCard extends HTMLElement {
         self._updateContent();
       });
     });
+    root.querySelectorAll('[data-repotted-entity]').forEach(function(el) {
+      el.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var input = root.querySelector('#repotted-input-' + el.dataset.plantId);
+        var val   = input ? input.value.trim() : '';
+        self._setValue(el.dataset.repottedEntity, val);
+        self._press(el.dataset.repottedBtn);
+      });
+    });
   }
 
   _plants() {
@@ -266,6 +319,11 @@ class AdaptivePlantCard extends HTMLElement {
         if (!isNaN(parsed)) moistureVal = parsed;
       }
 
+      // Latin / scientific name — null if entity absent or unavailable
+      var latinSt   = st('_latin_name');
+      var latinName = (latinSt && latinSt.state && latinSt.state !== 'unknown' && latinSt.state !== 'unavailable')
+        ? latinSt.state : null;
+
       return {
         id:                   devId,
         name:                 dev.name_by_user || dev.name || 'Plant',
@@ -285,8 +343,13 @@ class AdaptivePlantCard extends HTMLElement {
         btnSnooze:            find('_snooze_today_s_tasks'),
         btnFert:              find('_mark_fertilized'),
         btnConfirmHealth:     find('_confirm_health'),
+        btnRepotted:          find('_mark_repotted'),
+        lastRepotted:         st('_last_repotted')         ? st('_last_repotted').state         : null,
+        repottedDateInputId:  find('_repotted_on'),
+        repottedDateInput:    (st('_repotted_on') && st('_repotted_on').state && st('_repotted_on').state !== 'unknown') ? st('_repotted_on').state : '',
         moistureVal:          moistureVal,   // float or null
         hasMoisture:          moistureVal !== null,
+        latinName:            latinName,     // string or null
       };
     }).sort(function(a, b) { return a.name.localeCompare(b.name); });
   }
@@ -356,21 +419,10 @@ class AdaptivePlantCard extends HTMLElement {
     var color   = overdue ? this._icons.health_confirm_overdue_color : this._icons.health_confirm_color;
     var label   = overdue ? 'Update Due' : 'Confirm Health';
     var icon    = this._renderIcon(this._icons.health_confirm, color, '15px');
-    var bgAlpha = '26';
-    var bg      = color + bgAlpha;
+    var bg      = color + '26';
     return '<button class="detail-btn btn-health" style="color:' + color + ';background:' + bg + ';" data-entity="' + p.btnConfirmHealth + '">' +
       icon + ' ' + label +
     '</button>';
-  }
-
-  // ── Moisture pill for overview meta row ──────────────────────────────────────
-  _moisturePill(p) {
-    var pct   = Math.round(p.moistureVal);
-    var color = '#64b4ff';
-    return '<span class="meta-item moisture-pill">' +
-      this._renderIcon(this._icons.water, color, '12px') +
-      ' <span style="color:' + color + ';font-weight:600;">' + pct + '%</span>' +
-    '</span>';
   }
 
   _renderToday(plants) {
@@ -400,6 +452,7 @@ class AdaptivePlantCard extends HTMLElement {
             self._avatar(p, 'today') +
             '<div class="plant-info">' +
               '<div class="plant-name">' + p.name + '</div>' +
+              self._latinNameHtml(p) +
               (self._showText('today') && p.health ? '<div class="plant-meta"><span class="health-badge" style="color:' + self._healthColor(p.health) + '">' + self._capitalise(p.health) + '</span></div>' : '') +
               '<div class="chips">' + (wu ? self._waterChip(p.daysWater) : '') + (fu ? self._fertChip(p.daysFert) : '') + '</div>' +
             '</div>' +
@@ -472,6 +525,7 @@ class AdaptivePlantCard extends HTMLElement {
               self._avatar(p, 'upcoming') +
               '<div class="plant-info">' +
                 '<div class="plant-name">' + p.name + '</div>' +
+                self._latinNameHtml(p) +
                 (self._showText('upcoming') && p.health ? '<div class="plant-meta"><span class="health-badge" style="color:' + self._healthColor(p.health) + '">' + self._capitalise(p.health) + '</span></div>' : '') +
                 '<div class="chips">' +
                   (pg.water ? '<span class="chip chip-water">' + self._renderIcon(self._icons.water,     self._icons.water_color,     '13px') + ' ' + pg.water.lbl + '</span>' : '') +
@@ -525,8 +579,6 @@ class AdaptivePlantCard extends HTMLElement {
           var showTxt = self._showText('overview');
 
           // v13: in the meta row, show moisture % instead of watering days
-          // when the plant has an active moisture reading and the option is on.
-          // Falls back to days string if moisture is unavailable.
           var waterMeta;
           if (self._showMoistureInOverview && p.hasMoisture) {
             waterMeta = self._moisturePill(p);
@@ -536,20 +588,22 @@ class AdaptivePlantCard extends HTMLElement {
             waterMeta = '';
           }
 
-          var hopts   = ['excellent','good','poor','sick'];
+          var hopts = ['excellent','good','poor','sick'];
           var row = '<div class="plant-row plant-row-click" data-expand="' + p.id + '">' +
             self._avatar(p, 'overview') +
             '<div class="plant-info">' +
               '<div class="plant-name">' + p.name + (urgent ? '<span class="urgent-dot"></span>' : '') + '</div>' +
+              self._latinNameHtml(p) +
               '<div class="plant-meta">' +
                 (showTxt && p.health ? '<span class="health-badge" style="color:' + self._healthColor(p.health) + '">' + self._capitalise(p.health) + '</span>' : '') +
                 waterMeta +
-                (p.daysFert  ? '<span class="meta-item">' + self._renderIcon(self._icons.fertilize, self._icons.fertilize_color, '12px') + ' ' + p.daysFert  + '</span>' : '') +
+                (p.daysFert ? '<span class="meta-item">' + self._renderIcon(self._icons.fertilize, self._icons.fertilize_color, '12px') + ' ' + p.daysFert + '</span>' : '') +
               '</div>' +
             '</div>' +
             '<div class="chevron">' + (isExp ? '▲' : '▼') + '</div>' +
           '</div>';
           if (!isExp) return row;
+
           var en = self._editingNotes === p.id;
           var notesHtml = '';
           if (p.notesEntityId) {
@@ -565,18 +619,39 @@ class AdaptivePlantCard extends HTMLElement {
                 '<span class="notes-edit-icon">✏️</span>' +
                 '</div></div>';
           }
+
+          // ── Repotted section ──────────────────────────────────────────────
+          // Last repotted date: always visible when plant has repotting configured
+          // Repotted-on date input: hidden when show_repotting is off
+          // Mark Repotted button: moved to detail-actions (rendered below)
+          var repottedRows = '';
+          if (p.btnRepotted) {
+            var lastRepottedVal = (p.lastRepotted && p.lastRepotted !== 'unknown' && p.lastRepotted !== 'unavailable')
+              ? '<span class="detail-value">' + p.lastRepotted + '</span>'
+              : '<span class="detail-value" style="color:var(--secondary-text-color,#888);font-style:italic;">Never</span>';
+            repottedRows = '<div class="detail-row"><span class="detail-label">Last repotted</span>' + lastRepottedVal + '</div>';
+            if (self._showRepotting) {
+              repottedRows += '<div class="detail-row repotted-row">' +
+                '<span class="detail-label">Repotted on</span>' +
+                '<input class="repotted-input" id="repotted-input-' + p.id + '" type="text" placeholder="YYYY-MM-DD (optional)" value="' + p.repottedDateInput + '" maxlength="10" />' +
+              '</div>';
+            }
+          }
+
           var detail = '<div class="plant-detail">' +
             (p.nextWatering   ? '<div class="detail-row"><span class="detail-label">Next watering</span><span class="detail-value">' + p.nextWatering + '</span></div>' : '') +
             (p.hasMoisture    ? '<div class="detail-row"><span class="detail-label">Soil moisture</span><span class="detail-value" style="color:#64b4ff;font-weight:600;">' + Math.round(p.moistureVal) + '%</span></div>' : '') +
             (p.nextFertilized ? '<div class="detail-row"><span class="detail-label">Next fertilization</span><span class="detail-value">' + p.nextFertilized + '</span></div>' : '') +
+            repottedRows +
             (p.healthEntityId ? '<div class="detail-row"><span class="detail-label">Health</span>' +
               '<select class="health-select" data-health-entity="' + p.healthEntityId + '">' +
                 hopts.map(function(o) { return '<option value="' + o + '"' + (o === p.health ? ' selected' : '') + '>' + self._capitalise(o) + '</option>'; }).join('') +
               '</select></div>' : '') +
             notesHtml +
             '<div class="detail-actions">' +
-              (p.btnWater         ? '<button class="detail-btn btn-water"  data-entity="' + p.btnWater        + '">' + self._renderIcon(self._icons.water,     self._icons.water_color,     '15px') + ' Mark Watered</button>'    : '') +
-              (p.btnFert          ? '<button class="detail-btn btn-fert"   data-entity="' + p.btnFert         + '">' + self._renderIcon(self._icons.fertilize, self._icons.fertilize_color, '15px') + ' Mark Fertilized</button>' : '') +
+              (p.btnWater         ? '<button class="detail-btn btn-water"  data-entity="' + p.btnWater  + '">' + self._renderIcon(self._icons.water,     self._icons.water_color,     '15px') + ' Mark Watered</button>'    : '') +
+              (p.btnFert          ? '<button class="detail-btn btn-fert"   data-entity="' + p.btnFert   + '">' + self._renderIcon(self._icons.fertilize, self._icons.fertilize_color, '15px') + ' Mark Fertilized</button>' : '') +
+              (self._showRepotting && p.btnRepotted ? self._repottedBtn(p) : '') +
               (p.btnConfirmHealth ? self._confirmHealthBtn(p) : '') +
             '</div>' +
           '</div>';
@@ -674,6 +749,7 @@ class AdaptivePlantCard extends HTMLElement {
       '.avatar-wrap{flex-shrink:0;}.avatar{width:44px;height:44px;border-radius:50%;overflow:hidden;background:#2a2a2a;display:flex;align-items:center;justify-content:center;transition:box-shadow 0.2s;}',
       '.avatar img{width:100%;height:100%;object-fit:cover;}.av-init{font-size:15px;font-weight:700;color:#7cb97e;}',
       '.plant-info{flex:1;min-width:0;}.plant-name{font-size:15px;font-weight:500;display:flex;align-items:center;gap:6px;}',
+      '.plant-latin{font-style:italic;line-height:1.3;}',
       '.plant-meta{display:flex;gap:8px;margin-top:3px;flex-wrap:wrap;align-items:center;}',
       '.meta-item{font-size:12px;color:var(--secondary-text-color,#888);display:flex;align-items:center;gap:3px;}.health-badge{font-size:12px;font-weight:600;}',
       '.moisture-pill{color:#64b4ff;}',
@@ -701,6 +777,10 @@ class AdaptivePlantCard extends HTMLElement {
       '.detail-btn{padding:7px 14px;border-radius:20px;border:none;cursor:pointer;font-size:13px;font-weight:500;display:inline-flex;align-items:center;gap:5px;transition:filter 0.15s;}',
       '.detail-btn.btn-water{background:rgba(100,180,255,0.15);color:#64b4ff;}.detail-btn.btn-fert{background:rgba(124,185,126,0.15);color:#7cb97e;}',
       '.detail-btn.btn-health{transition:filter 0.15s;}',
+      '.detail-btn.btn-repotted{white-space:nowrap;}',
+      '.repotted-row{gap:6px;}',
+      '.repotted-input{flex:1;min-width:0;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:var(--primary-text-color,#e5e5e5);font-size:13px;padding:5px 8px;outline:none;font-family:inherit;box-sizing:border-box;}',
+      '.repotted-input:focus{border-color:' + this._repottedButtonColor + ';}',
       '.detail-btn:hover{filter:brightness(1.25);}',
       '.empty{display:flex;flex-direction:column;align-items:center;padding:48px 16px;color:var(--secondary-text-color,#888);gap:8px;}',
       '.empty-icon{font-size:36px;}.empty p{margin:0;font-size:14px;}',
@@ -803,6 +883,22 @@ class AdaptivePlantCardEditor extends HTMLElement {
       '</div>' +
         '<div class="field-hint">These options only affect plants with an active moisture sensor reporting a value. Plants without a sensor are unaffected.</div>' +
       '</div>' +
+      '<div class="field-group"><div class="field-label">Repotting</div><div class="toggle-row">' +
+        this._toggle('Show Mark Repotting button & date input', 'show_repotting', this._get('show_repotting', true)) +
+      '</div>' +
+        '<div class="field-hint">When off, only the last repotted date is shown — the date input and button are hidden for all plants. Can still be set & updated via the integration page.</div>' +
+      '</div>' +
+      '<div class="field-group"><div class="field-label">Latin / Scientific name</div>' +
+        '<div class="toggle-row">' +
+          this._toggle('Show latin name below plant name', 'show_latin_name', this._get('show_latin_name', false)) +
+        '</div>' +
+        '<div class="field-hint">Reads from each plant\'s <em>_latin_name</em> text entity. Displayed in all three tabs.</div>' +
+        '<div class="field-row" style="margin-top:6px;">' +
+          this._textField('Font size (px)', 'latin_name_size', this._get('latin_name_size', ''), 'e.g. 11', 'number') +
+          this._colorField('Color', 'latin_name_color', this._get('latin_name_color', '#888888')) +
+        '</div>' +
+        this._textField('Vertical padding (px)', 'latin_name_padding', this._get('latin_name_padding', ''), 'e.g. 1', 'number') +
+      '</div>' +
       '<div class="field-group"><div class="field-label">Label alignment</div>' +
         '<div class="tri-btns" style="gap:6px;">' +
           '<button class="tri-btn ' + (align === 'left'   ? 'active-def' : '') + '" data-tri="label_align" data-val="left">Left</button>'   +
@@ -888,7 +984,7 @@ class AdaptivePlantCardEditor extends HTMLElement {
     var self = this;
     var row = function(label, ip, cp, di, dc) {
       return '<div class="icon-row"><span class="icon-label">' + label + '</span><div class="icon-inputs">' +
-        self._textField('Icon', ip, self._get(ip, di), di) + self._colorField('Color', cp, self._get(cp, dc)) +
+        self._textField('Icon', ip, self._get(ip, di), di || 'none') + self._colorField('Color', cp, self._get(cp, dc)) +
       '</div></div>';
     };
     return row('Water chip',          'icons.water',                        'icons.water_color',                  '💧',              '#64b4ff') +
@@ -900,7 +996,15 @@ class AdaptivePlantCardEditor extends HTMLElement {
            '<div class="icon-row"><span class="icon-label">Update Due color</span><div class="icon-inputs">' +
              '<div class="field-hint" style="margin:0;grid-column:1/-1;">Color used for both icon and button when a health check-in is overdue.</div>' +
              self._colorField('Overdue color', 'icons.health_confirm_overdue_color', self._get('icons.health_confirm_overdue_color', '#e05c5c')) +
-           '</div></div>';
+           '</div></div>' +
+           '<div class="icon-row">' +
+             '<span class="icon-label">Mark Repotted button</span>' +
+             '<div class="field-hint" style="margin:4px 0 6px;">Leave icon blank for a text-only button. Accepts emoji or MDI (e.g. <em>mdi:pot</em>).</div>' +
+             '<div class="icon-inputs">' +
+               self._textField('Icon (optional)', 'repotted_button_icon',  self._get('repotted_button_icon',  ''), 'e.g. mdi:pot') +
+               self._colorField('Color',          'repotted_button_color', self._get('repotted_button_color', '#c8975a')) +
+             '</div>' +
+           '</div>';
   }
 
   _toggle(label, path, value) {


### PR DESCRIPTION
This is the biggest release yet, bringing improvements to the integration, the card, and the blueprint all at once. To my knowledge, Adaptive Plant is now the most comprehensive plant care and tracking integration available for Home Assistant — if you know of one that does more, let me know! If you've found this project useful, a ⭐ on the repository would mean a lot.

### 🌱 Integration v1.1.0
**Repotting Tracking (new)**

Optional feature — enable during setup or any time via Configure
Records the last repotted date on the device page
Use the "Repotted on" text field to enter a past date (YYYY-MM-DD) before pressing Mark Repotted — the field clears automatically after
Selecting "Haven't repotted yet" correctly shows the sensor as unknown

**Latin Name**

The latin name field is now editable directly from the device page via a text entity — previously it could only be set during the initial setup wizard
Can also be enabled after setup via Configure

**Fertilization**

Fertilization tracking can now be enabled after setup — open Configure and toggle Enable fertilization tracking on; you'll be prompted for the last fertilized date
Previous dates are preserved if you disable and re-enable
Note: after enabling, set your desired interval via the device page or Configure, then press Mark Fertilized once for the interval to take effect

**Notes**

Notes can now be enabled and disabled after setup — open Configure and toggle Enable notes on
Previously this could only be set during the initial setup wizard


### **🪴 Card v14**
Repotting Tracking

New repotting support added to each plant's detail panel — log when a plant was repotted with an optional date, or just press the button to mark it repotted today
The "Last repotted" date is always visible in the expanded detail view once set
New show_repotting toggle (default: on) — disable it to hide the date input and button for a cleaner view while still showing the last repotted date
The Mark Repotted button sits in the main action bar alongside Mark Watered, Mark Fertilized, and Confirm Health
repotted_button_color and repotted_button_icon allow full customization — accepts emoji or MDI icons (e.g. mdi:pot); leave icon blank for a text-only button

Latin / Scientific Name Display

New show_latin_name option (default: off) displays each plant's scientific name in italics directly below the common name in all three tabs (Today, Upcoming, Overview)
Reads from each plant's _latin_name entity — plants without this entity are unaffected
Fully customizable via the visual editor: latin_name_size (px), latin_name_color, and latin_name_padding (vertical spacing in px)


### **🔧 Blueprint Bug Fix**

Optional reminder times (time 2 and time 3) were silently not firing due to a Jinja2 filter bug — if your optional times aren't working, re-import the updated blueprint and recreate your automation to fix it