### PR TITLE
Allow enabling and setting the plant image from the options flow

### DIFF
--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -473,14 +473,18 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 # Toggle off — remove stored latin name
                 cleaned.pop(CONF_LATIN_NAME, None)
 
-            # Image path — handle the text field when image is enabled.
+            # Image toggle — write explicitly, and handle the text field.
             # Empty string is written as a tombstone (mirroring CONF_LABEL and
             # CONF_LATIN_NAME) so the PlantData.image_path property's fallback
             # to entry.data doesn't resurface a stale value set during the
             # original setup wizard.
-            if entry.data.get(CONF_ENABLE_IMAGE):
+            image_enabled = bool(user_input.get(CONF_ENABLE_IMAGE, False))
+            cleaned[CONF_ENABLE_IMAGE] = image_enabled
+            if image_enabled:
                 raw_image = user_input.get(CONF_IMAGE_PATH, "")
                 cleaned[CONF_IMAGE_PATH] = raw_image.strip() if raw_image else ""
+            else:
+                cleaned.pop(CONF_IMAGE_PATH, None)
 
             # Handle moisture sensor selection.
             # The toggle is the authoritative clear mechanism — if it's off we
@@ -535,6 +539,7 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     CONF_ENABLE_LATIN_NAME,
                     CONF_FERTILIZATION_ENABLED,
                     CONF_REPOTTING_ENABLED,
+                    CONF_ENABLE_IMAGE,
                 }
                 for k, v in user_input.items():
                     if k not in _skip_clear and v in (None, "") and k in merged:
@@ -595,14 +600,6 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             ),
         }
 
-        if entry.data.get(CONF_ENABLE_IMAGE):
-            schema_fields[
-                vol.Optional(
-                    CONF_IMAGE_PATH,
-                    description={"suggested_value": defaults.get(CONF_IMAGE_PATH, "")},
-                )
-            ] = selector.selector({"text": {}})
-
         # ── Toggles — grouped together at the bottom ─────────────────────────
         # Notes toggle — always shown, options override takes priority over entry.data
         notes_currently_enabled = bool(
@@ -652,6 +649,22 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 vol.Optional(
                     CONF_LATIN_NAME,
                     description={"suggested_value": current_latin},
+                )
+            ] = selector.selector({"text": {}})
+
+        # Image toggle — always shown so users can enable it after setup.
+        # If already enabled, also show the path field to edit the value.
+        image_currently_enabled = bool(
+            current_opts.get(CONF_ENABLE_IMAGE, entry.data.get(CONF_ENABLE_IMAGE, False))
+        )
+        schema_fields[vol.Required(CONF_ENABLE_IMAGE, default=image_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+        if image_currently_enabled:
+            schema_fields[
+                vol.Optional(
+                    CONF_IMAGE_PATH,
+                    description={"suggested_value": defaults.get(CONF_IMAGE_PATH, "")},
                 )
             ] = selector.selector({"text": {}})
 

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -150,6 +150,9 @@ class PlantData:
 
     @property
     def enable_image(self) -> bool:
+        # Options override takes precedence — allows enabling after setup.
+        if CONF_ENABLE_IMAGE in self._entry.options:
+            return bool(self._entry.options[CONF_ENABLE_IMAGE])
         return bool(self._entry.data.get(CONF_ENABLE_IMAGE, False))
 
     @property

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -137,6 +137,7 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "enable_image": "Enable image",
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -137,6 +137,7 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "enable_image": "Enable image",
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",


### PR DESCRIPTION
## Problem
The plant image is the only optional feature that can't be enabled or changed after initial setup. Notes, fertilization, repotting, and Latin name all expose their Enable toggle in the options (Configure) flow; image does not — its path field and save handler are gated on `entry.data[CONF_ENABLE_IMAGE]`. A plant set up without an image can never get a picture through the UI afterward.

## Fix
Adds the `enable_image` toggle to `AdaptivePlantOptionsFlow.async_step_init`, mirroring the existing Latin-name pattern: toggle always shown, path field shown when enabled, both persisted to options. Also updates `PlantData.enable_image` to read from options first (mirroring `enable_latin_name`), so enabling the image post-setup actually applies the picture instead of staying gated on the original `entry.data` value. Adds the corresponding `enable_image` string to `strings.json` and `translations/en.json`.

## Testing
`py_compile` clean on `config_flow.py` and `plant.py`; JSON validated. Traced both the moisture-sensor and non-moisture save paths in the options flow to confirm `enable_image`/`image_path` carry through correctly in both. No `tests/` directory or pre-commit config exists in this repo to run.

## Summary of changes (4 files):
- `config_flow.py`: replaced the entry.data-gated image path block with an always-shown `enable_image` toggle (grouped with the other feature toggles) + conditional path field; save handler now writes the toggle explicitly and tombstones the path when disabled; added `CONF_ENABLE_IMAGE` to `_skip_clear`.
- `plant.py`: `PlantData.enable_image` now checks `entry.options` first, falling back to `entry.data` — same pattern as `enable_latin_name` — so toggling it on in Configure actually takes effect.
- `strings.json` / `translations/en.json`: added the `enable_image` label.

