### PR TITLE
Add plant image upload

### DIFF
--- a/custom_components/adaptive_plant/__init__.py
+++ b/custom_components/adaptive_plant/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.event import (
 
 from .const import (
     CONF_AREA,
+    CONF_IMAGE_PATH,
     DEFAULT_HEALTH,
     DOMAIN,
     HEALTH_OPTIONS,
@@ -36,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 _CARD_URL = f"/{DOMAIN}/adaptive-plant-card.js"
 _CARD_PATH = Path(__file__).parent / "frontend" / "adaptive-plant-card.js"
 _BLUEPRINTS_SRC = Path(__file__).parent / "blueprints" / "automation"
+_OWNED_IMAGE_PREFIX = f"/local/{DOMAIN}/"
 
 
 async def _async_register_frontend(hass: HomeAssistant) -> None:
@@ -213,3 +215,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unloaded
+
+
+def _delete_owned_image(config_dir: str, image_path: str) -> None:
+    """Blocking: best-effort delete of an owned image file under www/adaptive_plant/."""
+    filename = image_path[len(_OWNED_IMAGE_PREFIX):]
+    full_path = Path(config_dir) / "www" / DOMAIN / filename
+    try:
+        full_path.unlink()
+    except OSError:
+        pass
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clean up an owned uploaded image when the config entry is removed."""
+    image_path = entry.options.get(CONF_IMAGE_PATH, entry.data.get(CONF_IMAGE_PATH))
+    if image_path and image_path.startswith(_OWNED_IMAGE_PREFIX):
+        await hass.async_add_executor_job(_delete_owned_image, hass.config.config_dir, image_path)

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -1,12 +1,16 @@
 """Config flow for the Adaptive Plant integration."""
 from __future__ import annotations
 
+import logging
+import os
+import uuid
 from datetime import date, timedelta
 
 import voluptuous as vol
 
+from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
@@ -24,6 +28,7 @@ from .const import (
     CONF_FERTILIZATION_ENABLED,
     CONF_HEALTH_PROMPT_INTERVAL,
     CONF_IMAGE_PATH,
+    CONF_IMAGE_UPLOAD,
     CONF_INITIAL_LAST_FERTILIZED,
     CONF_INITIAL_LAST_WATERED,
     CONF_LABEL,
@@ -49,6 +54,10 @@ from .const import (
     STATE_LAST_REPOTTED,
     STATE_NEXT_FERTILIZED,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+OWNED_IMAGE_PREFIX = f"/local/{DOMAIN}/"
 
 WATERING_DATE_TODAY = "today"
 WATERING_DATE_YESTERDAY = "yesterday"
@@ -178,6 +187,7 @@ def _latin_name_schema(defaults: dict) -> vol.Schema:
 
 def _image_schema(defaults: dict) -> vol.Schema:
     return vol.Schema({
+        vol.Optional(CONF_IMAGE_UPLOAD): selector.selector({"file": {"accept": "image/*"}}),
         vol.Optional(CONF_IMAGE_PATH, default=defaults.get(CONF_IMAGE_PATH, "")): selector.selector(
             {"text": {}}
         ),
@@ -210,6 +220,67 @@ def _resolve_date(selection: str, custom_date: str | None, interval: int) -> tup
         return None, today.isoformat()
     next_date = last + timedelta(days=interval)
     return last.isoformat(), next_date.isoformat()
+
+
+def _is_owned_image_path(path: str | None) -> bool:
+    """Return True if `path` is a file we created (and may safely delete)."""
+    return bool(path) and path.startswith(OWNED_IMAGE_PREFIX)
+
+
+def _save_uploaded_image(hass: HomeAssistant, file_id: str, previous_path: str | None) -> str:
+    """Blocking: read the uploaded file, downscale it, and write it to www/.
+
+    Runs entirely inside an executor job — must not be awaited directly.
+    """
+    from PIL import Image
+
+    target_dir = hass.config.path("www", DOMAIN)
+    os.makedirs(target_dir, exist_ok=True)
+    filename = f"{uuid.uuid4().hex}.jpg"
+    target_path = os.path.join(target_dir, filename)
+
+    try:
+        from pillow_heif import register_heif_opener
+        register_heif_opener()
+    except ImportError:
+        pass
+
+    with process_uploaded_file(hass, file_id) as temp_path:
+        with Image.open(temp_path) as img:
+            from PIL import ImageOps
+            img = ImageOps.exif_transpose(img)
+            img = img.convert("RGB")
+            img.thumbnail((1024, 1024))
+            img.save(target_path, format="JPEG", quality=85)
+
+    if _is_owned_image_path(previous_path):
+        previous_filename = previous_path[len(OWNED_IMAGE_PREFIX):]
+        previous_full_path = os.path.join(target_dir, previous_filename)
+        try:
+            os.remove(previous_full_path)
+        except OSError:
+            pass
+
+    return f"{OWNED_IMAGE_PREFIX}{filename}"
+
+
+def _delete_owned_image(hass: HomeAssistant, path: str) -> None:
+    """Blocking: best-effort delete of an owned image file. Run in an executor job."""
+    filename = path[len(OWNED_IMAGE_PREFIX):]
+    full_path = os.path.join(hass.config.path("www", DOMAIN), filename)
+    try:
+        os.remove(full_path)
+    except OSError:
+        pass
+
+
+async def _persist_uploaded_image(hass: HomeAssistant, file_id: str, previous_path: str | None) -> str:
+    """Persist an uploaded image to www/adaptive_plant/ and return its public path.
+
+    Raises on failure (corrupt/non-image upload) so callers can surface
+    an `invalid_image` form error.
+    """
+    return await hass.async_add_executor_job(_save_uploaded_image, hass, file_id, previous_path)
 
 
 class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -385,11 +456,25 @@ class AdaptivePlantConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_image(self, user_input: dict | None = None) -> FlowResult:
         errors: dict[str, str] = {}
         if user_input is not None:
+            file_id = user_input.get(CONF_IMAGE_UPLOAD)
             path = user_input.get(CONF_IMAGE_PATH, "").strip()
-            if path and not path.startswith("/local/"):
-                errors[CONF_IMAGE_PATH] = "invalid_image_path"
+            if file_id:
+                try:
+                    self._data[CONF_IMAGE_PATH] = await _persist_uploaded_image(
+                        self.hass, file_id, self._data.get(CONF_IMAGE_PATH)
+                    )
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Failed to process uploaded plant image")
+                    errors[CONF_IMAGE_UPLOAD] = "invalid_image"
+            elif path:
+                if not path.startswith("/local/"):
+                    errors[CONF_IMAGE_PATH] = "invalid_image_path"
+                else:
+                    self._data[CONF_IMAGE_PATH] = path
             else:
-                self._data[CONF_IMAGE_PATH] = path or None
+                self._data[CONF_IMAGE_PATH] = None
+
+            if not errors:
                 if self._data.get(CONF_MOISTURE_SENSOR):
                     return await self.async_step_moisture()
                 return self._create_entry()
@@ -454,6 +539,7 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             clear_label = (not label_stripped) or label_stripped.lower() == "null"
 
             cleaned = {k: v for k, v in user_input.items() if v not in (None, "")}
+            cleaned.pop(CONF_IMAGE_UPLOAD, None)
 
             # Normalise label: drop from `cleaned` unconditionally, then re-add
             # the stripped value only if the user didn't intend to clear it.
@@ -508,18 +594,51 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 raw_care = user_input.get(CONF_CARE_INSTRUCTIONS, "")
                 cleaned[CONF_CARE_INSTRUCTIONS] = (raw_care or "")[:2000]
 
-            # Image toggle — write explicitly, and handle the text field.
+            # Image toggle — write explicitly, and handle the upload/text field.
             # Empty string is written as a tombstone (mirroring CONF_LABEL and
             # CONF_LATIN_NAME) so the PlantData.image_path property's fallback
             # to entry.data doesn't resurface a stale value set during the
             # original setup wizard.
             image_enabled = bool(user_input.get(CONF_ENABLE_IMAGE, False))
             cleaned[CONF_ENABLE_IMAGE] = image_enabled
+            current_image_path = current_opts.get(CONF_IMAGE_PATH, entry.data.get(CONF_IMAGE_PATH))
             if image_enabled:
-                raw_image = user_input.get(CONF_IMAGE_PATH, "")
-                cleaned[CONF_IMAGE_PATH] = raw_image.strip() if raw_image else ""
+                upload_file_id = user_input.get(CONF_IMAGE_UPLOAD)
+                if upload_file_id:
+                    try:
+                        cleaned[CONF_IMAGE_PATH] = await _persist_uploaded_image(
+                            self.hass, upload_file_id, current_image_path
+                        )
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.exception("Failed to process uploaded plant image")
+                        errors[CONF_IMAGE_UPLOAD] = "invalid_image"
+                else:
+                    raw_image = user_input.get(CONF_IMAGE_PATH, "")
+                    new_path = raw_image.strip() if raw_image else ""
+                    cleaned[CONF_IMAGE_PATH] = new_path
+                    if new_path != current_image_path and _is_owned_image_path(current_image_path):
+                        await self.hass.async_add_executor_job(
+                            _delete_owned_image, self.hass, current_image_path
+                        )
             else:
-                cleaned.pop(CONF_IMAGE_PATH, None)
+                # Image disabled — tombstone the path (mirroring CONF_LABEL /
+                # CONF_LATIN_NAME) rather than popping. We also delete the owned
+                # file below, so a bare pop would leave a stale path in options
+                # that resurfaces as a broken image if the user re-enables
+                # without re-uploading. The "" tombstone is preserved through
+                # `merged` by _skip_clear and makes image_path resolve to None.
+                cleaned[CONF_IMAGE_PATH] = ""
+                if _is_owned_image_path(current_image_path):
+                    await self.hass.async_add_executor_job(
+                        _delete_owned_image, self.hass, current_image_path
+                    )
+
+            if errors:
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=vol.Schema(self._init_schema_fields()),
+                    errors=errors,
+                )
 
             # Handle moisture sensor selection.
             # The toggle is the authoritative clear mechanism — if it's off we
@@ -615,6 +734,16 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
 
                 return await self._route_first_enable()
 
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(self._init_schema_fields()),
+            errors=errors,
+        )
+
+    def _init_schema_fields(self) -> dict:
+        """Build the field dict for the `init` step schema (also used to re-show on error)."""
+        entry = self._config_entry
+        current_opts = entry.options
         defaults = {**entry.data, **current_opts}
 
         # Resolve the currently active moisture sensor. Key-presence check
@@ -726,6 +855,9 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             {"boolean": {}}
         )
         if image_currently_enabled:
+            schema_fields[vol.Optional(CONF_IMAGE_UPLOAD)] = selector.selector(
+                {"file": {"accept": "image/*"}}
+            )
             schema_fields[
                 vol.Optional(
                     CONF_IMAGE_PATH,
@@ -746,11 +878,7 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             {"entity": {"domain": "sensor", "multiple": False}}
         )
 
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(schema_fields),
-            errors=errors,
-        )
+        return schema_fields
 
     async def async_step_moisture_options(self, user_input: dict | None = None) -> FlowResult:
         """Second step shown only when a moisture sensor has been selected."""

--- a/custom_components/adaptive_plant/const.py
+++ b/custom_components/adaptive_plant/const.py
@@ -12,6 +12,8 @@ CONF_ENABLE_FERTILIZATION = "enable_fertilization"
 CONF_ENABLE_NOTES = "enable_notes"
 CONF_ENABLE_IMAGE = "enable_image"
 CONF_IMAGE_PATH = "image_path"
+# Transient, form-only field for the file-upload selector — never persisted.
+CONF_IMAGE_UPLOAD = "image_upload"
 CONF_MOISTURE_SENSOR = "moisture_sensor"
 CONF_DRY_THRESHOLD = "dry_threshold"
 CONF_WET_THRESHOLD = "wet_threshold"

--- a/custom_components/adaptive_plant/manifest.json
+++ b/custom_components/adaptive_plant/manifest.json
@@ -3,7 +3,7 @@
   "name": "Adaptive Plant",
   "codeowners": ["@Big-Xan"],
   "config_flow": true,
-  "dependencies": ["http"],
+  "dependencies": ["file_upload", "http"],
   "documentation": "https://github.com/Big-Xan/adaptive_plant",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Big-Xan/adaptive_plant/issues",

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -95,9 +95,13 @@
       },
       "image": {
         "title": "Plant Image",
-        "description": "Enter a path to an image in your /local/ folder (e.g. /local/IMG_4743.jpeg).",
+        "description": "Upload a photo, or enter a path to an image in your /local/ folder (e.g. /local/IMG_4743.jpeg).",
         "data": {
+          "image_upload": "Upload image",
           "image_path": "Image path (/local/...)"
+        },
+        "data_description": {
+          "image_upload": "Pick a photo from your device. Takes priority over the path below."
         }
       },
       "latin_name": {
@@ -119,6 +123,7 @@
     "error": {
       "name_required": "Plant name cannot be empty.",
       "invalid_image_path": "Image path must start with /local/.",
+      "invalid_image": "Could not process the uploaded image. Please choose a different file.",
       "dry_above_wet": "Dry threshold must be less than wet threshold.",
       "invalid_date": "Please enter a valid date."
     },
@@ -138,6 +143,7 @@
           "health_prompt_interval_days": "Health prompt interval (days)",
           "fertilization_interval_days": "Fertilization interval (days)",
           "fertilization_sync_window": "Sync fertilization to watering within (days)",
+          "image_upload": "Upload image",
           "image_path": "Image path (/local/...)",
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
@@ -159,7 +165,8 @@
           "care_instructions": "Free-form care notes shown read-only on the card. Type \\*\\*bold\\*\\* to make text **bold**. Line breaks are supported.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic.",
-          "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval."
+          "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval.",
+          "image_upload": "Pick a photo from your device. Takes priority over the path below."
         }
       },
       "moisture_options": {
@@ -216,7 +223,8 @@
     "error": {
       "dry_above_wet": "Dry threshold must be less than wet threshold.",
       "invalid_date": "Please enter a valid date.",
-      "invalid_image_path": "Image path must start with /local/."
+      "invalid_image_path": "Image path must start with /local/.",
+      "invalid_image": "Could not process the uploaded image. Please choose a different file."
     }
   },
   "entity": {

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -95,9 +95,13 @@
       },
       "image": {
         "title": "Plant Image",
-        "description": "Enter a path to an image in your /local/ folder (e.g. /local/IMG_4743.jpeg).",
+        "description": "Upload a photo, or enter a path to an image in your /local/ folder (e.g. /local/IMG_4743.jpeg).",
         "data": {
+          "image_upload": "Upload image",
           "image_path": "Image path (/local/...)"
+        },
+        "data_description": {
+          "image_upload": "Pick a photo from your device. Takes priority over the path below."
         }
       },
       "latin_name": {
@@ -119,6 +123,7 @@
     "error": {
       "name_required": "Plant name cannot be empty.",
       "invalid_image_path": "Image path must start with /local/.",
+      "invalid_image": "Could not process the uploaded image. Please choose a different file.",
       "dry_above_wet": "Dry threshold must be less than wet threshold.",
       "invalid_date": "Please enter a valid date."
     },
@@ -138,6 +143,7 @@
           "health_prompt_interval_days": "Health prompt interval (days)",
           "fertilization_interval_days": "Fertilization interval (days)",
           "fertilization_sync_window": "Sync fertilization to watering within (days)",
+          "image_upload": "Upload image",
           "image_path": "Image path (/local/...)",
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
@@ -159,7 +165,8 @@
           "care_instructions": "Free-form care notes shown read-only on the card. Type \\*\\*bold\\*\\* to make text **bold**. Line breaks are supported.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic.",
-          "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval."
+          "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval.",
+          "image_upload": "Pick a photo from your device. Takes priority over the path below."
         }
       },
       "moisture_options": {
@@ -216,7 +223,8 @@
     "error": {
       "dry_above_wet": "Dry threshold must be less than wet threshold.",
       "invalid_date": "Please enter a valid date.",
-      "invalid_image_path": "Image path must start with /local/."
+      "invalid_image_path": "Image path must start with /local/.",
+      "invalid_image": "Could not process the uploaded image. Please choose a different file."
     }
   },
   "entity": {


### PR DESCRIPTION
## Add image upload to the config & options flows (JPEG/PNG)

Lets users attach a plant photo by picking a file, instead of only typing a
`/local/` path. Rebased on `main` now that the enable-image toggle (#17) has
merged — so this PR is just the upload half, layered on top of that toggle.

### What it does
- File-upload selector in the image step of both the setup wizard and the
  post-setup options flow.
- Uploads are processed in an executor (off the event loop): EXIF-orientation
  fix, downscale to 1024px, re-encode to JPEG.
- Owned-file lifecycle: saved files live only under `/local/adaptive_plant/`
  and are cleaned up on re-upload, disable, and entry removal — nothing outside
  that folder is ever touched.

### Dependencies / compatibility
- **No new Python packages** — `requirements` stays `[]`. Processing rides on
  the Pillow that Home Assistant already bundles, so it works on the 2024.6
  floor and on all architectures (incl. 32-bit ARM).
- The only manifest change is adding the built-in `file_upload` component to
  `dependencies`.

### HEIC
- Dropped the hard `pillow-heif` requirement (per maintainer discussion). HEIC
  stays behind a `try/except ImportError` guard, so it lights up automatically
  if/when HA's bundled Pillow reaches 11.1.0.
- Trade-off for now: an iPhone HEIC upload surfaces the existing `invalid_image`
  form error. JPEG/PNG are the supported formats.