### PR TITLE
Add optional per-plant care instructions field

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ entry/plant afterwards (**Settings → Devices & Services → Adaptive Plant →
 - Free-form text field stored per plant
 - Can be enabled or disabled at any time via Configure — no restart required
 
+### 📖 Care Instructions (optional)
+- Store longer, free-form care guidance per plant — light, watering, soil, feeding,
+  repotting tips, whatever you've gathered for that species
+- Handles long, multi-line text — where **Notes** is meant for short jottings,
+  Care Instructions is for full write-ups
+- Basic formatting: wrap text in `**double asterisks**` for bold headings, and
+  line breaks are preserved
+- Edited in the integration's settings (**Configure**) and shown read-only in the
+  expanded plant detail on the companion card's Overview tab
+- Enable or disable per plant at any time via Configure — no restart required
+
+> **Tip:** Adaptive Plant won't tell you *how* to care for a plant (see the [FAQ](#-faq))
+> — Care Instructions is simply where you record the guidance *you've* gathered, so it's
+> on hand right next to the plant.
+
 ### 🖼️ Plant Image (optional)
 - Attach a `/local/` image path to display on dashboard cards. Can be changed via configuration after entry is created. I recommend creating a folder titled 'adaptive_plant' in your `/www/` folder and uploading your plant images there.
 > **Example image pathway (w/ folder created) for card config:**  `/local/adaptive_plant/monstera.png`
@@ -179,7 +194,7 @@ Hard refresh your browser (Ctrl+Shift+R / Cmd+Shift+R) after installing or updat
 
 - **Today tab** — plants due or overdue, grouped by area and label. Mark watered, mark fertilized, or snooze directly from the card. Hold the button at the bottom to complete all tasks at once. The snooze button remains visible until all of a plant's tasks for the day are resolved.
 - **Upcoming tab** — future waterings and fertilizations with a configurable day cutoff. Plants with both tasks due on the same day appear as a single combined row. Mark tasks early directly from the card.
-- **Overview tab** — all plants grouped by area and label, with a configurable sort order (alphabetical, health, or days until watering). Expand any plant to see next watering/fertilization dates, edit health, add notes, confirm health check-in, and mark tasks complete.
+- **Overview tab** — all plants grouped by area and label, with a configurable sort order (alphabetical, health, or days until watering). Expand any plant to see next watering/fertilization dates, edit health, add notes, view care instructions, confirm health check-in, and mark tasks complete.
 - **Labels** — plants with a label assigned are grouped under a sublabel header within their area, across all tabs
 - **Health ring** — colored ring around each plant avatar indicating health status, configurable per tab
 - **Confirm Health button** — always visible in the Overview expanded detail. Shows a heart icon and reads "Update Due" when a health check-in is overdue. Color configurable.
@@ -409,8 +424,8 @@ the card.
 **What happens if I delete a plant and re-add it?**
 
 All state is stored in the config entry — last watered date, next
-watering, fertilization dates, repotting history, notes, health, and the
-adapted watering interval. Deleting the entry permanently deletes all of
+watering, fertilization dates, repotting history, notes, care instructions,
+health, and the adapted watering interval. Deleting the entry permanently deletes all of
 that. Re-adding the plant starts completely fresh.
 
 If you need to change a setting, always use **Configure** rather than

--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -12,8 +12,10 @@ from homeassistant.helpers import selector
 
 from .const import (
     CONF_AREA,
+    CONF_CARE_INSTRUCTIONS,
     CONF_DRY_THRESHOLD,
     CONF_EARLY_WATERING_THRESHOLD,
+    CONF_ENABLE_CARE_INSTRUCTIONS,
     CONF_ENABLE_FERTILIZATION,
     CONF_ENABLE_IMAGE,
     CONF_ENABLE_LATIN_NAME,
@@ -473,6 +475,16 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 # Toggle off — remove stored latin name
                 cleaned.pop(CONF_LATIN_NAME, None)
 
+            # Care instructions toggle — write explicitly, and handle the text field.
+            care_enabled = bool(user_input.get(CONF_ENABLE_CARE_INSTRUCTIONS, False))
+            cleaned[CONF_ENABLE_CARE_INSTRUCTIONS] = care_enabled
+            if care_enabled:
+                # Store raw text (no strip) so multiline formatting survives; an
+                # empty string is an intentional clear (tombstone).
+                cleaned[CONF_CARE_INSTRUCTIONS] = user_input.get(CONF_CARE_INSTRUCTIONS, "") or ""
+            else:
+                cleaned.pop(CONF_CARE_INSTRUCTIONS, None)
+
             # Image toggle — write explicitly, and handle the text field.
             # Empty string is written as a tombstone (mirroring CONF_LABEL and
             # CONF_LATIN_NAME) so the PlantData.image_path property's fallback
@@ -537,6 +549,8 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     CONF_MOISTURE_SENSOR,
                     CONF_NOTES_ENABLED,
                     CONF_ENABLE_LATIN_NAME,
+                    CONF_CARE_INSTRUCTIONS,
+                    CONF_ENABLE_CARE_INSTRUCTIONS,
                     CONF_FERTILIZATION_ENABLED,
                     CONF_REPOTTING_ENABLED,
                     CONF_ENABLE_IMAGE,
@@ -651,6 +665,22 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     description={"suggested_value": current_latin},
                 )
             ] = selector.selector({"text": {}})
+
+        # Care instructions toggle — always shown so users can enable it after
+        # setup. If enabled, show a multiline text box (markdown-ish: **bold**).
+        care_currently_enabled = bool(
+            current_opts.get(CONF_ENABLE_CARE_INSTRUCTIONS, False)
+        )
+        schema_fields[vol.Required(CONF_ENABLE_CARE_INSTRUCTIONS, default=care_currently_enabled)] = selector.selector(
+            {"boolean": {}}
+        )
+        if care_currently_enabled:
+            schema_fields[
+                vol.Optional(
+                    CONF_CARE_INSTRUCTIONS,
+                    description={"suggested_value": defaults.get(CONF_CARE_INSTRUCTIONS, "")},
+                )
+            ] = selector.selector({"text": {"multiline": True, "max": 2000}})
 
         # Image toggle — always shown so users can enable it after setup.
         # If already enabled, also show the path field to edit the value.

--- a/custom_components/adaptive_plant/const.py
+++ b/custom_components/adaptive_plant/const.py
@@ -18,6 +18,8 @@ CONF_WET_THRESHOLD = "wet_threshold"
 CONF_LABEL = "label"
 CONF_ENABLE_LATIN_NAME = "enable_latin_name"
 CONF_LATIN_NAME = "latin_name"
+CONF_ENABLE_CARE_INSTRUCTIONS = "enable_care_instructions"
+CONF_CARE_INSTRUCTIONS = "care_instructions"
 CONF_NOTES_ENABLED = "notes_enabled"
 CONF_ENABLE_REPOTTING = "enable_repotting"
 

--- a/custom_components/adaptive_plant/frontend/adaptive-plant-card.js
+++ b/custom_components/adaptive_plant/frontend/adaptive-plant-card.js
@@ -196,6 +196,16 @@ class AdaptivePlantCard extends HTMLElement {
       .replace(/'/g, '&#39;');
   }
 
+  // ── Render care instructions: escape first, then a tiny safe subset ───────
+  // Runs _esc() first so any real HTML in the user's text is neutralised; only
+  // our own literal <b>/<br> tags are added afterwards. Supports **bold** and
+  // line breaks — intentionally not full markdown.
+  _careHtml(s) {
+    return this._esc(s)
+      .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')   // **bold** → bold
+      .replace(/\n/g, '<br>');                  // keep line breaks
+  }
+
   // ── Build a translucent background from any CSS color string ─────────────
   // Replaces the prior `color + '26'` / `color + '22'` string-concat hack,
   // which silently produced invalid CSS for non-hex inputs (named colors,
@@ -494,6 +504,7 @@ class AdaptivePlantCard extends HTMLElement {
         moistureVal:          moistureVal,   // float or null
         hasMoisture:          moistureVal !== null,
         latinName:            latinName,     // string or null
+        careInstructions:     nwAt.care_instructions || null,
       };
     }).sort(function(a, b) { return a.name.localeCompare(b.name); });
   }
@@ -764,6 +775,14 @@ class AdaptivePlantCard extends HTMLElement {
                 '</div></div>';
           }
 
+          // ── Care instructions section (read-only, **bold** + line breaks) ──
+          var careHtml = '';
+          if (p.careInstructions) {
+            careHtml = '<div class="care-section"><span class="detail-label">Care</span>' +
+              '<div class="care-body">' + self._careHtml(p.careInstructions) + '</div>' +
+            '</div>';
+          }
+
           // ── Repotted section ──────────────────────────────────────────────
           // Last repotted date: always visible when plant has repotting configured
           // Repotted-on date input: hidden when show_repotting is off
@@ -792,6 +811,7 @@ class AdaptivePlantCard extends HTMLElement {
                 hopts.map(function(o) { return '<option value="' + o + '"' + (o === p.health ? ' selected' : '') + '>' + self._capitalise(o) + '</option>'; }).join('') +
               '</select></div>' : '') +
             notesHtml +
+            careHtml +
             '<div class="detail-actions">' +
               (p.btnWater         ? '<button class="detail-btn btn-water"  data-entity="' + p.btnWater  + '">' + self._renderIcon(self._icons.water,     self._icons.water_color,     '15px') + ' Mark Watered</button>'    : '') +
               (p.btnFert          ? '<button class="detail-btn btn-fert"   data-entity="' + p.btnFert   + '">' + self._renderIcon(self._icons.fertilize, self._icons.fertilize_color, '15px') + ' Mark Fertilized</button>' : '') +
@@ -933,6 +953,8 @@ class AdaptivePlantCard extends HTMLElement {
       '.notes-input{width:100%;box-sizing:border-box;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.15);border-radius:8px;color:var(--primary-text-color,#e5e5e5);font-size:13px;padding:8px;resize:vertical;min-height:72px;outline:none;font-family:inherit;}',
       '.notes-actions{display:flex;gap:8px;margin-top:6px;}.notes-save,.notes-cancel{padding:5px 14px;border-radius:16px;border:none;font-size:12px;font-weight:600;cursor:pointer;}',
       '.notes-save{background:#7cb97e;color:#fff;}.notes-cancel{background:rgba(255,255,255,0.08);color:#aaa;}',
+      '.care-section{margin:6px 0;font-size:13px;}.care-section .detail-label{display:block;margin-bottom:4px;}',
+      '.care-body{font-size:13px;line-height:1.45;color:var(--primary-text-color,#e5e5e5);}',
       '.detail-actions{display:flex;gap:8px;margin-top:10px;flex-wrap:wrap;}',
       '.detail-btn{padding:7px 14px;border-radius:20px;border:none;cursor:pointer;font-size:13px;font-weight:500;display:inline-flex;align-items:center;gap:5px;transition:filter 0.15s;}',
       '.detail-btn.btn-water{background:rgba(100,180,255,0.15);color:#64b4ff;}.detail-btn.btn-fert{background:rgba(124,185,126,0.15);color:#7cb97e;}',

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -15,8 +15,10 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_AREA,
+    CONF_CARE_INSTRUCTIONS,
     CONF_DRY_THRESHOLD,
     CONF_EARLY_WATERING_THRESHOLD,
+    CONF_ENABLE_CARE_INSTRUCTIONS,
     CONF_ENABLE_FERTILIZATION,
     CONF_ENABLE_IMAGE,
     CONF_ENABLE_LATIN_NAME,
@@ -132,6 +134,12 @@ class PlantData:
         return bool(self._entry.data.get(CONF_ENABLE_LATIN_NAME, False))
 
     @property
+    def enable_care_instructions(self) -> bool:
+        # Care instructions are edited only in the options flow, so the value
+        # lives solely in options — no entry.data fallback needed.
+        return bool(self._entry.options.get(CONF_ENABLE_CARE_INSTRUCTIONS, False))
+
+    @property
     def enable_repotting(self) -> bool:
         # Options override takes precedence — allows toggling after setup.
         if CONF_REPOTTING_ENABLED in self._entry.options:
@@ -147,6 +155,13 @@ class PlantData:
             return val.strip() if val and val.strip() else None
         val = self._entry.data.get(CONF_LATIN_NAME)
         return val.strip() if val and val.strip() else None
+
+    @property
+    def care_instructions(self) -> str | None:
+        # Stored only in options. Return the raw value (no strip) so multiline
+        # formatting survives; treat all-whitespace as "no value".
+        val = self._entry.options.get(CONF_CARE_INSTRUCTIONS)
+        return val if (val and val.strip()) else None
 
     @property
     def enable_image(self) -> bool:

--- a/custom_components/adaptive_plant/sensor.py
+++ b/custom_components/adaptive_plant/sensor.py
@@ -118,10 +118,12 @@ class NextWateringSensor(PlantSensorBase):
 
     @property
     def extra_state_attributes(self) -> dict:
-        """Expose label as an attribute so the companion card can read it."""
+        """Expose label + care instructions as attributes for the companion card."""
         attrs = {}
         if self._plant.label:
             attrs["label"] = self._plant.label
+        if self._plant.enable_care_instructions and self._plant.care_instructions:
+            attrs["care_instructions"] = self._plant.care_instructions
         return attrs
 
 

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -137,6 +137,8 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "enable_care_instructions": "Enable care instructions",
+          "care_instructions": "Care instructions",
           "enable_image": "Enable image",
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
@@ -146,6 +148,8 @@
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",
           "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
+          "enable_care_instructions": "Toggle to enable or disable care instructions for this plant.",
+          "care_instructions": "Free-form care notes shown read-only on the card. **bold** and line breaks are supported.",
           "fertilization_enabled": "Toggle to enable or disable fertilization tracking. Previous dates are preserved when re-enabled.",
           "repotting_enabled": "Toggle to enable or disable repotting tracking. Previous dates are preserved when re-enabled.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -137,6 +137,8 @@
           "notes_enabled": "Enable notes",
           "latin_name": "Latin name",
           "enable_latin_name": "Enable latin name",
+          "enable_care_instructions": "Enable care instructions",
+          "care_instructions": "Care instructions",
           "enable_image": "Enable image",
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
@@ -146,6 +148,8 @@
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",
           "notes_enabled": "Toggle to enable or disable the notes field for this plant.",
+          "enable_care_instructions": "Toggle to enable or disable care instructions for this plant.",
+          "care_instructions": "Free-form care notes shown read-only on the card. **bold** and line breaks are supported.",
           "fertilization_enabled": "Toggle to enable or disable fertilization tracking. Previous dates are preserved when re-enabled.",
           "repotting_enabled": "Toggle to enable or disable repotting tracking. Previous dates are preserved when re-enabled.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",


### PR DESCRIPTION
## What
Adds an optional **Care Instructions** field per plant — free-form, multi-line text
for recording care guidance (light, watering, soil, feeding, repotting tips, etc.).
Disabled by default; enabled per plant via **Configure**.

## Why
The existing **Notes** field is backed by a `TextEntity`, so it's capped at Home
Assistant's 255-char entity-state limit — too short for a real care write-up. This
field is for longer reference text. It also somewhat fits the project's stated
philosophy (see the FAQ — "Adaptive Plant doesn't tell you *how* to care for a
plant"): it's a place to store the guidance *you've* gathered, not
integration-prescribed care.

## How it works
- Stored in the config-entry **options** (not an entity state), which sidesteps the
  255-char cap and allows long, multi-line text.
- Surfaced as a `care_instructions` **attribute** on the existing `next_watering`
  sensor (only when enabled and non-empty) so the companion card can read it — no
  new entity is created.
- Edited in the **options flow** via a multiline text selector, gated behind its own
  toggle (mirrors the Latin name feature), and **capped at 2,000 characters**.
  Intentionally options-flow-only — not added to the setup wizard.
- **Length cap rationale:** because the text is exposed as a sensor attribute, an
  unbounded paste could bloat the config-entry store and trip HA's recorder
  attribute-size limit (~16 KB), which would stop recording the sensor's history.
  2,000 chars stays ~14× under that byte limit and is still generous (a thorough,
  multi-section guide with emoji is ~1,100 chars).
- Rendered **read-only** in the card's Overview expanded detail. Supports `**bold**`
  and line breaks via a small escape-first transform (no markdown library, left this
  out to keep it light).

## Design / constraints respected
- **No new dependencies** — `manifest.json` `requirements` stays `[]`; just stdlib/HA
  plus a few lines of card JS.
- Fully local; no external calls.
- **Additive and fail-safe** — disabled by default, follows the existing
  optional-feature patterns (enable toggle, options-override read, `""` tombstone
  preserved via `_skip_clear`). No migration, no breaking changes.

## Changes
- `const.py` — two keys (`enable_care_instructions`, `care_instructions`)
- `plant.py` — `enable_care_instructions` + `care_instructions` properties
- `config_flow.py` — options-flow toggle, multiline field (2,000-char cap),
  tombstone handling
- `sensor.py` — `care_instructions` attribute on `NextWateringSensor`
- `frontend/adaptive-plant-card.js` — reads the attribute, read-only "Care" section,
  `**bold**`/newline rendering, CSS
- `strings.json` / `translations/en.json` — labels + descriptions
- `README.md` — Features entry and companion mentions

## Trade-offs considered (deliberately not done)
- **Not added to the setup wizard** — kept options-flow-only so it doesn't touch the
  four setup routing branches; care text is better added/edited after a plant exists.
- **Reused the `next_watering` sensor's attributes** instead of adding a dedicated
  entity — the card already reads them, so nothing new is created. The 2,000-char cap
  keeps that attribute clear of the recorder's size limit.
- **Bold + line breaks only, not full markdown** — avoids pulling in `ha-markdown`
  or a parser; keeps the change dependency-free and light.
- **No inline editing on the card** — would require the integration's first custom
  service to persist text beyond the 255-char service/state limits; editing via the
  settings dialog avoids that entirely.
- **Cap enforced at input only (selector `max`), not by truncating on read** —
  config-entry options can't be set via YAML/import here, so the bypass risk is
  negligible; read-side truncation would be silent, could split a `**bold**` pair or
  an emoji, and wouldn't bound the stored value anyway.

## Testing
- Static checks pass: `py_compile` on the changed Python modules, JSON validated,
  `node --check` on the card.
- End-to-end check: enable Care Instructions via Configure, paste a long (>255 char)
  note with a `**bold**` heading and line breaks → confirm it persists, appears as
  the `care_instructions` attribute on `sensor.<plant>_next_watering`, and renders
  read-only (bold + line breaks) in the card's Overview detail; toggle off → the
  attribute disappears. The field rejects input beyond 2,000 characters.

## Screenshot
<img width="755" height="824" alt="bild" src="https://github.com/user-attachments/assets/a2a349ec-4f83-4e15-87e8-f68fa8d37376" />
