### PR TITLE
Recompute next watering/fertilizing date when the interval changes

### DIFF
--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -54,8 +54,11 @@ from .const import (
     OWNED_IMAGE_PREFIX,
     STATE_LAST_FERTILIZED,
     STATE_LAST_REPOTTED,
+    STATE_LAST_WATERED,
     STATE_NEXT_FERTILIZED,
+    STATE_NEXT_WATERING,
 )
+from .plant import next_due
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -669,6 +672,51 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             moisture_raw = user_input.get(CONF_MOISTURE_SENSOR) if moisture_enabled else None
             # Remove the toggle key — it's UI-only, not stored in options
             cleaned.pop("moisture_sensor_enabled", None)
+
+            # Reschedule the next due-date when an interval changed. next_watering
+            # / next_fertilized are stored values, otherwise only recomputed by
+            # runtime events (mark_watered, daily rollover, moisture handlers) —
+            # so without this an interval edit saves but the card's next-due date
+            # and days-until don't move until the next watering/fert event. We
+            # recompute from the last event date (shared next_due helper, same as
+            # the interval number entities) so the new cadence takes effect now.
+            # Written into `cleaned`, which both save paths overlay onto a fresh
+            # read in _save() — so the recomputed date wins over the stored one.
+            # This resets next_watering to last_watered + interval, discarding any
+            # in-period snooze / early-watering nudge to the date — an explicit
+            # interval change is a fresh reschedule; the counters are runtime
+            # state, left as-is. Watering bows out for moisture-sensor plants
+            # (`moisture_raw`): the sensor owns the date there and may have set it
+            # to "today" when dry — pushing it to last_watered + interval would
+            # wrongly defer a due watering (and clobber a concurrent sensor write).
+            # Fertilization has no such guard — it runs on its own schedule for
+            # every plant, mirroring set_fertilization_interval.
+            new_water_interval = user_input.get(OPT_WATERING_INTERVAL)
+            old_water_interval = current_opts.get(
+                OPT_WATERING_INTERVAL, entry.data.get(OPT_WATERING_INTERVAL)
+            )
+            if (
+                not moisture_raw
+                and new_water_interval is not None
+                and old_water_interval is not None
+                and new_water_interval != old_water_interval
+            ):
+                new_next = next_due(current_opts.get(STATE_LAST_WATERED), new_water_interval)
+                if new_next:
+                    cleaned[STATE_NEXT_WATERING] = new_next
+
+            new_fert_interval = user_input.get(OPT_FERTILIZATION_INTERVAL)
+            old_fert_interval = current_opts.get(
+                OPT_FERTILIZATION_INTERVAL, entry.data.get(OPT_FERTILIZATION_INTERVAL)
+            )
+            if (
+                new_fert_interval is not None
+                and old_fert_interval is not None
+                and new_fert_interval != old_fert_interval
+            ):
+                new_next = next_due(current_opts.get(STATE_LAST_FERTILIZED), new_fert_interval)
+                if new_next:
+                    cleaned[STATE_NEXT_FERTILIZED] = new_next
 
             if moisture_raw:
                 self._pending_moisture_sensor = moisture_raw

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -65,6 +65,20 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def next_due(last_event: str | None, interval: int) -> str | None:
+    """Next due-date = last event date + interval days, or None if not computable.
+
+    Shared by the options flow and the interval number entities so editing an
+    interval through either door reschedules the stored next-due date the same way.
+    """
+    if not last_event:
+        return None
+    try:
+        return (date.fromisoformat(last_event) + timedelta(days=int(interval))).isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
 class PlantData:
     """Encapsulates all state and logic for a single plant."""
 
@@ -451,7 +465,20 @@ class PlantData:
         await self._persist(updates)
 
     async def set_watering_interval(self, days: int) -> None:
-        await self._persist({OPT_WATERING_INTERVAL: int(days)})
+        # Reschedule next watering onto the new cadence right away, mirroring the
+        # options flow — otherwise the number entity is a second door to the same
+        # setting that leaves the next-due date stale until the next event. Only
+        # on an actual change (a no-op set must not discard a snooze/early-watering
+        # adjustment to the date) and only for schedule-driven plants: moisture
+        # plants are sensor-driven (next watering can be "today" when dry), so the
+        # sensor owns the date — this bows out like mark_watered / the fert-sync block.
+        days = int(days)
+        updates: dict = {OPT_WATERING_INTERVAL: days}
+        if days != self.watering_interval and not self.moisture_sensor:
+            new_next = next_due(self.last_watered, days)
+            if new_next:
+                updates[STATE_NEXT_WATERING] = new_next
+        await self._persist(updates)
 
     async def snooze_watering(self) -> None:
         """Push next watering and/or fertilization forward by 1 day if due or overdue.
@@ -533,7 +560,17 @@ class PlantData:
         })
 
     async def set_fertilization_interval(self, days: int) -> None:
-        await self._persist({OPT_FERTILIZATION_INTERVAL: int(days)})
+        # Mirror set_watering_interval — reschedule next fertilizing onto the new
+        # cadence so this number entity isn't a second door that leaves the date
+        # stale. No moisture guard: fertilization runs on its own schedule for
+        # every plant (mark_fertilized has no moisture bow-out, unlike watering).
+        days = int(days)
+        updates: dict = {OPT_FERTILIZATION_INTERVAL: days}
+        if days != self.fertilization_interval:
+            new_next = next_due(self.last_fertilized, days)
+            if new_next:
+                updates[STATE_NEXT_FERTILIZED] = new_next
+        await self._persist(updates)
 
     # ── Notes ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Editing a plant's **watering or fertilization interval** in the options flow saves the new interval, but the **next-due date doesn't move** — the card's "Next Watering" / "Days Until Watering" stay on the old date until the next actual watering/fertilizing event.

## Cause

`PlantData.next_watering` / `next_fertilized` return the **stored** `next_watering` / `next_fertilized` values, which are only recomputed by runtime events (`mark_watered`, the daily rollover, the moisture handlers) — never when the interval is changed through the options flow. So an interval edit persists, but the derived schedule stays stale until the next event resets it.

## Fix

In `AdaptivePlantOptionsFlow.async_step_init`, when an interval actually changes, recompute the matching next-due date as `last_watered + new interval` (resp. `last_fertilized + new interval`) and write it into the saved options. It's added to `cleaned`, so it propagates through both the no-moisture and the moisture-options save paths. Guarded to only fire when the interval changed **and** a last-event date exists; the date math reuses the same `date.fromisoformat(...) + timedelta(days=...)` pattern already used elsewhere in the flow.

## Note

An explicit interval change is treated as a fresh reschedule, so it resets `next_watering` to `last_watered + interval` — which discards any in-period **snooze / early-watering adjustment to the date**. The snooze / early-watering **counters** are left untouched. Happy to gate the reschedule on `snoozed_this_period` instead if you'd rather preserve an active snooze.
