### PR TITLE
Edit moisture thresholds on the options page (inline; second step only for first-time sensor enable)

### DIFF
--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -646,11 +646,29 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
 
             if moisture_raw:
                 self._pending_moisture_sensor = moisture_raw
-                # Carry non-moisture fields forward so they're saved after thresholds
+                # Carry non-moisture fields forward so they're saved with the thresholds.
                 self._pending_opts = cleaned
                 # Carry the clear-label intent forward — step 2's merge would
                 # otherwise pull the stale value back in from current_opts.
                 self._pending_clear_label = clear_label
+                # Dry/wet thresholds are shown inline on the main form whenever a
+                # sensor is already active (see _init_schema_fields), so they can be
+                # edited on demand and saved in one step. They are absent only on a
+                # first-time enable — the form was built with the sensor off, so the
+                # fields couldn't be shown — in which case we collect them once in the
+                # dedicated step.
+                inline_dry = user_input.get(CONF_DRY_THRESHOLD)
+                inline_wet = user_input.get(CONF_WET_THRESHOLD)
+                if inline_dry is not None and inline_wet is not None:
+                    if inline_dry >= inline_wet:
+                        return self.async_show_form(
+                            step_id="init",
+                            data_schema=vol.Schema(self._init_schema_fields()),
+                            errors={"base": "dry_above_wet"},
+                        )
+                    return await self.async_step_moisture_options(
+                        {CONF_DRY_THRESHOLD: inline_dry, CONF_WET_THRESHOLD: inline_wet}
+                    )
                 return await self.async_step_moisture_options()
             else:
                 # Sensor cleared — tombstone the sensor and strip thresholds.
@@ -872,6 +890,19 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
         schema_fields[sensor_field] = selector.selector(
             {"entity": {"domain": "sensor", "multiple": False}}
         )
+
+        # When a sensor is already active, show its dry/wet thresholds inline so
+        # they can be edited here on demand. The dedicated threshold step is then
+        # only needed for a first-time sensor enable (the form is built once, so a
+        # sensor toggled on in THIS submission can't reveal these fields yet).
+        # Same selector spec as _moisture_schema.
+        if current_moisture:
+            schema_fields[
+                vol.Required(CONF_DRY_THRESHOLD, default=defaults.get(CONF_DRY_THRESHOLD, 30.0))
+            ] = selector.selector({"number": {"min": 0, "max": 100, "step": 0.1, "mode": "box"}})
+            schema_fields[
+                vol.Required(CONF_WET_THRESHOLD, default=defaults.get(CONF_WET_THRESHOLD, 70.0))
+            ] = selector.selector({"number": {"min": 0, "max": 100, "step": 0.1, "mode": "box"}})
 
         return schema_fields
 

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -154,7 +154,9 @@
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",
-          "moisture_sensor": "Moisture sensor"
+          "moisture_sensor": "Moisture sensor",
+          "dry_threshold": "Dry threshold (reschedule watering to today)",
+          "wet_threshold": "Wet threshold (auto-mark as watered)"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -154,7 +154,9 @@
           "fertilization_enabled": "Enable fertilization tracking",
           "repotting_enabled": "Enable repotting tracking",
           "moisture_sensor_enabled": "Enable moisture sensor",
-          "moisture_sensor": "Moisture sensor"
+          "moisture_sensor": "Moisture sensor",
+          "dry_threshold": "Dry threshold (reschedule watering to today)",
+          "wet_threshold": "Wet threshold (auto-mark as watered)"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",


### PR DESCRIPTION
## Problem

Dry/wet thresholds could only be set via a separate step that appears when a moisture sensor is **added or changed**. Two consequences:

- After the initial setup you **can't adjust thresholds on demand** — you'd have to remove and re-add the sensor to get the threshold form back.
- For a plant that already has a sensor, that step appeared on **every** options save, and the save only committed after it — so closing the dialog there silently discarded the whole edit.

## Fix

Show the dry/wet thresholds **inline on the main options form** whenever a sensor is already active — mirroring how the latin-name and image fields are shown when those features are enabled. Now thresholds are editable on demand and saved in one step.

The dedicated threshold step is kept **only for a first-time sensor enable**: HA builds the form once, so a sensor toggled on in the *same* submission can't reveal the threshold fields yet — that single case still collects them in the follow-up step (exactly as before).

## Details

- `_init_schema_fields`: append `dry_threshold` / `wet_threshold` (same selector spec as the setup wizard's `_moisture_schema`) when a sensor is currently set, defaulting to the stored values.
- `async_step_init`: when the inline thresholds are present, validate `dry < wet` and save in one step (reusing `async_step_moisture_options` as the save path so the merge + first-enable routing is unchanged); when absent (first-time enable), fall through to the threshold step.
- Adds the `init`-step `dry_threshold` / `wet_threshold` labels in `strings.json` / `translations/en.json`; reuses the existing `dry_above_wet` error.

## Behaviour notes

- Disabling the sensor still clears the thresholds.
- Two pre-existing UX quirks are unchanged (already true for the latin/image fields): a validation error re-renders the form from stored values, and the threshold fields stay visible if you untoggle the sensor in the same session.

(Independent of #21.)
