### PR TITLE
Fix repeated repot/fertilize date prompt when editing options

### DIFF
--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -709,6 +709,12 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 latin_was_enabled = bool(
                     current_opts.get(CONF_ENABLE_LATIN_NAME, entry.data.get(CONF_ENABLE_LATIN_NAME, False))
                 )
+                fertilization_was_enabled = bool(
+                    current_opts.get(CONF_FERTILIZATION_ENABLED, entry.data.get(CONF_ENABLE_FERTILIZATION, False))
+                )
+                repotting_was_enabled = bool(
+                    current_opts.get(CONF_REPOTTING_ENABLED, entry.data.get(CONF_ENABLE_REPOTTING, False))
+                )
                 self._pending_opts = merged
                 self._pending_image_first = (
                     cleaned.get(CONF_ENABLE_IMAGE) is True and not image_was_enabled
@@ -716,14 +722,19 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 self._pending_latin_first = (
                     cleaned.get(CONF_ENABLE_LATIN_NAME) is True and not latin_was_enabled
                 )
-                # Fertilization: toggle just turned on AND no last_fertilized yet
+                # Fertilization: toggle flipped on this save, wasn't already active, and no date yet.
+                # The not-already-active guard mirrors the image/latin gates above; without it any
+                # later edit re-fires this sub-step while a date is genuinely absent (e.g. "never
+                # fertilized"), and a preserved date survives a disable→enable cycle untouched.
                 self._pending_fert_first = (
                     cleaned.get(CONF_FERTILIZATION_ENABLED) is True
+                    and not fertilization_was_enabled
                     and STATE_LAST_FERTILIZED not in current_opts
                 )
-                # Repotting: toggle just turned on AND no last_repotted yet
+                # Repotting: same three-part guard as fertilization.
                 self._pending_repot_first = (
                     cleaned.get(CONF_REPOTTING_ENABLED) is True
+                    and not repotting_was_enabled
                     and STATE_LAST_REPOTTED not in current_opts
                 )
 
@@ -912,6 +923,12 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 latin_was_enabled = bool(
                     current_opts.get(CONF_ENABLE_LATIN_NAME, entry.data.get(CONF_ENABLE_LATIN_NAME, False))
                 )
+                fertilization_was_enabled = bool(
+                    current_opts.get(CONF_FERTILIZATION_ENABLED, entry.data.get(CONF_ENABLE_FERTILIZATION, False))
+                )
+                repotting_was_enabled = bool(
+                    current_opts.get(CONF_REPOTTING_ENABLED, entry.data.get(CONF_ENABLE_REPOTTING, False))
+                )
                 self._pending_opts = merged
                 self._pending_image_first = (
                     self._pending_opts.get(CONF_ENABLE_IMAGE) is True and not image_was_enabled
@@ -921,10 +938,12 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 )
                 self._pending_fert_first = (
                     self._pending_opts.get(CONF_FERTILIZATION_ENABLED) is True
+                    and not fertilization_was_enabled
                     and STATE_LAST_FERTILIZED not in current_opts
                 )
                 self._pending_repot_first = (
                     self._pending_opts.get(CONF_REPOTTING_ENABLED) is True
+                    and not repotting_was_enabled
                     and STATE_LAST_REPOTTED not in current_opts
                 )
 


### PR DESCRIPTION
### Problem

When repotting (or fertilization) tracking is enabled but the plant has no recorded date — e.g. the user chose **"Haven't repotted yet"**, or simply never pressed **Mark Repotted** — the options flow re-shows the *"When did you last repot/fertilize this plant?"* sub-step **every time any unrelated setting is saved** (watering interval, thresholds, etc.). It reads as a nag that won't go away.

### Cause

The first-enable gates for fertilization and repotting use only **date-absence** as the signal for "feature was just enabled":

```python
self._pending_repot_first = (
    cleaned.get(CONF_REPOTTING_ENABLED) is True
    and STATE_LAST_REPOTTED not in current_opts
)
```

The sibling **image/latin** gates right above also check that the feature *wasn't already active* (`and not image_was_enabled`), which is what the surrounding comment block describes as the intent. The fert/repot gates were missing that half, so a genuinely date-less plant re-triggers the sub-step on every save.

### Fix

Add the not-already-active guard **alongside** the existing date check (not replacing it), at both detection sites — `async_step_init` and `async_step_moisture_options` — for both features. This mirrors the image/latin gates and the established `*_was_enabled` helper expression.

Keeping the date check matters: fert/repot dates are deliberately preserved across a disable→enable cycle, and the sub-step's schema defaults to *today*. A pure transition guard would re-show the step on re-enable and let a preserved date get overwritten — the combined condition avoids that.

### A note on duplication

The first-enable detection runs in two places (`async_step_init` and `async_step_moisture_options`), so this adds the same guard to both. I kept it inline to match the existing structure rather than extracting a shared `_first_enable_pending(...)` helper — keeping the change surgical and the diff easy to read. If you'd prefer the four gates pulled into one helper, I'm happy to follow up; just let me know.

### Behaviour

| Scenario | Before | After |
|---|---|---|
| Enabled + edit an unrelated setting | prompts for date | no prompt |
| "Haven't repotted yet" + edit unrelated setting | prompts every save | no prompt |
| First enable via options (was off) | prompts | prompts (unchanged) |
| Disable → re-enable with a preserved date | no prompt | no prompt (date untouched) |
| Disable → re-enable, no date ever set | prompts | prompts |

The only firings removed are `enabled AND date-less AND already-active` — i.e. the nag. A date-less plant can still set its date any time via the card's **Mark Repotted** button.

Single-file change, no schema/entity/migration impact.

### Testing

- Reviewed against the documented intent of the detection block and the sibling image/latin gates it now mirrors.
- Walked the behaviour matrix above (already-enabled edits, "haven't repotted yet", genuine first-enable, disable→re-enable with and without a preserved date).
- `python -m py_compile` clean.
- Manually verified on a live install: with a repotting-enabled, date-less plant ("Haven't repotted yet"), editing an unrelated setting (watering interval) via the options flow no longer shows the repot date sub-step. The genuine first-enable (off→on) path is unchanged and covered by the behaviour matrix above.
