### PR TITLE
Add per-plant temperature/humidity passthrough sensors

### DIFF
--- a/custom_components/adaptive_plant/config_flow.py
+++ b/custom_components/adaptive_plant/config_flow.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_ENABLE_REPOTTING,
     CONF_FERTILIZATION_ENABLED,
     CONF_HEALTH_PROMPT_INTERVAL,
+    CONF_HUMIDITY_SENSOR,
     CONF_IMAGE_PATH,
     CONF_IMAGE_UPLOAD,
     CONF_INITIAL_LAST_FERTILIZED,
@@ -40,6 +41,7 @@ from .const import (
     CONF_REPOTTING_ENABLED,
     CONF_RESOLVED_LAST_REPOTTED,
     CONF_SNOOZE_THRESHOLD,
+    CONF_TEMPERATURE_SENSOR,
     CONF_WET_THRESHOLD,
     DEFAULT_EARLY_WATERING_THRESHOLD,
     DEFAULT_FERT_SYNC_WINDOW,
@@ -120,6 +122,12 @@ def _features_schema(defaults: dict) -> vol.Schema:
         vol.Required(CONF_ENABLE_REPOTTING, default=defaults.get(CONF_ENABLE_REPOTTING, False)): selector.selector({"boolean": {}}),
         vol.Optional(CONF_MOISTURE_SENSOR): selector.selector(
             {"entity": {"domain": "sensor", "multiple": False}}
+        ),
+        vol.Optional(CONF_TEMPERATURE_SENSOR): selector.selector(
+            {"entity": {"domain": "sensor", "device_class": "temperature", "multiple": False}}
+        ),
+        vol.Optional(CONF_HUMIDITY_SENSOR): selector.selector(
+            {"entity": {"domain": "sensor", "device_class": "humidity", "multiple": False}}
         ),
     })
 
@@ -871,6 +879,23 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                 if new_next:
                     cleaned[STATE_NEXT_FERTILIZED] = new_next
 
+            # Environment passthrough sensors (temperature, humidity) — display
+            # only, no thresholds and no dedicated sub-step. Same toggle+picker+
+            # empty-string-tombstone pattern as the moisture sensor (the entity
+            # selector can't be blanked in the UI, so the toggle is the clear
+            # mechanism). Resolved into `cleaned` here, before the moisture branch
+            # splits, so it propagates through both the moisture-options path and
+            # the no-moisture merge below. Both keys are in _skip_clear so the ""
+            # tombstone is preserved rather than marked for removal.
+            for _enable_key, _sensor_key in (
+                ("temperature_sensor_enabled", CONF_TEMPERATURE_SENSOR),
+                ("humidity_sensor_enabled", CONF_HUMIDITY_SENSOR),
+            ):
+                _enabled = bool(user_input.get(_enable_key, False))
+                _raw = user_input.get(_sensor_key) if _enabled else None
+                cleaned.pop(_enable_key, None)
+                cleaned[_sensor_key] = _raw or ""
+
             if moisture_raw:
                 self._pending_moisture_sensor = moisture_raw
                 # Carry non-moisture fields forward so they're saved with the thresholds.
@@ -939,6 +964,8 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
                     CONF_FERTILIZATION_ENABLED,
                     CONF_REPOTTING_ENABLED,
                     CONF_ENABLE_IMAGE,
+                    CONF_TEMPERATURE_SENSOR,
+                    CONF_HUMIDITY_SENSOR,
                 }
                 for k, v in user_input.items():
                     if k not in _skip_clear and v in (None, ""):
@@ -1153,6 +1180,30 @@ class AdaptivePlantOptionsFlow(OptionsFlow):
             schema_fields[
                 vol.Required(CONF_WET_THRESHOLD, default=defaults.get(CONF_WET_THRESHOLD, 70.0))
             ] = selector.selector({"number": {"min": 0, "max": 100, "step": 0.1, "mode": "box"}})
+
+        # Environment passthrough sensors (temperature, humidity) — toggle +
+        # device-class-filtered picker, same shape as the moisture sensor but
+        # with no thresholds (display only). Key-presence resolution mirrors
+        # PlantData so the empty-string tombstone written on disable shadows the
+        # stale setup-wizard value.
+        for _enable_key, _sensor_key, _device_class in (
+            ("temperature_sensor_enabled", CONF_TEMPERATURE_SENSOR, "temperature"),
+            ("humidity_sensor_enabled", CONF_HUMIDITY_SENSOR, "humidity"),
+        ):
+            if _sensor_key in current_opts:
+                _current_sensor = current_opts[_sensor_key] or None
+            else:
+                _current_sensor = entry.data.get(_sensor_key)
+            schema_fields[
+                vol.Required(_enable_key, default=bool(_current_sensor))
+            ] = selector.selector({"boolean": {}})
+            if _current_sensor:
+                _sensor_field = vol.Optional(_sensor_key, default=_current_sensor)
+            else:
+                _sensor_field = vol.Optional(_sensor_key)
+            schema_fields[_sensor_field] = selector.selector(
+                {"entity": {"domain": "sensor", "device_class": _device_class, "multiple": False}}
+            )
 
         return schema_fields
 

--- a/custom_components/adaptive_plant/const.py
+++ b/custom_components/adaptive_plant/const.py
@@ -34,6 +34,11 @@ CONF_IMAGE_UPLOAD = "image_upload"
 CONF_MOISTURE_SENSOR = "moisture_sensor"
 CONF_DRY_THRESHOLD = "dry_threshold"
 CONF_WET_THRESHOLD = "wet_threshold"
+# Environment passthrough sensors — display-only mirrors with no thresholds or
+# scheduling effect (unlike moisture, which drives the watering logic). Further
+# parameters (illuminance, conductivity, …) would follow the same pattern.
+CONF_TEMPERATURE_SENSOR = "temperature_sensor"
+CONF_HUMIDITY_SENSOR = "humidity_sensor"
 CONF_LABEL = "label"
 CONF_ENABLE_LATIN_NAME = "enable_latin_name"
 CONF_LATIN_NAME = "latin_name"

--- a/custom_components/adaptive_plant/frontend/adaptive-plant-card.js
+++ b/custom_components/adaptive_plant/frontend/adaptive-plant-card.js
@@ -1,4 +1,4 @@
-// Adaptive Plant Card v19.2
+// Adaptive Plant Card v19.3 — temperature/humidity passthrough detail rows
 
 class AdaptivePlantCard extends HTMLElement {
   constructor() {
@@ -498,6 +498,21 @@ class AdaptivePlantCard extends HTMLElement {
         if (!isNaN(parsed)) moistureVal = parsed;
       }
 
+      // Ambient temperature / humidity passthrough mirrors — display only.
+      // null when not configured or unavailable; unit follows the source sensor.
+      var tempSt   = st('_temperature');
+      var tempVal  = null, tempUnit = '°C';
+      if (tempSt && tempSt.state && tempSt.state !== 'unavailable' && tempSt.state !== 'unknown') {
+        var tParsed = parseFloat(tempSt.state);
+        if (!isNaN(tParsed)) { tempVal = tParsed; tempUnit = (tempSt.attributes && tempSt.attributes.unit_of_measurement) || '°C'; }
+      }
+      var humSt    = st('_humidity');
+      var humVal   = null, humUnit = '%';
+      if (humSt && humSt.state && humSt.state !== 'unavailable' && humSt.state !== 'unknown') {
+        var hParsed = parseFloat(humSt.state);
+        if (!isNaN(hParsed)) { humVal = hParsed; humUnit = (humSt.attributes && humSt.attributes.unit_of_measurement) || '%'; }
+      }
+
       // Latin / scientific name — null if entity absent or unavailable
       var latinSt   = st('_latin_name');
       var latinName = (latinSt && latinSt.state && latinSt.state !== 'unknown' && latinSt.state !== 'unavailable')
@@ -528,6 +543,12 @@ class AdaptivePlantCard extends HTMLElement {
         repottedDateInput:    (st('_repotted_on') && st('_repotted_on').state && st('_repotted_on').state !== 'unknown') ? st('_repotted_on').state : '',
         moistureVal:          moistureVal,   // float or null
         hasMoisture:          moistureVal !== null,
+        temperatureVal:       tempVal,       // float or null
+        temperatureUnit:      tempUnit,
+        hasTemperature:       tempVal !== null,
+        humidityVal:          humVal,        // float or null
+        humidityUnit:         humUnit,
+        hasHumidity:          humVal !== null,
         latinName:            latinName,     // string or null
         careInstructions:     nwAt.care_instructions || null,
       };
@@ -829,6 +850,8 @@ class AdaptivePlantCard extends HTMLElement {
           var detail = '<div class="plant-detail">' +
             (p.nextWatering   ? '<div class="detail-row"><span class="detail-label">Next watering</span><span class="detail-value">' + self._esc(p.nextWatering) + '</span></div>' : '') +
             (p.hasMoisture    ? '<div class="detail-row"><span class="detail-label">Soil moisture</span><span class="detail-value" style="color:#64b4ff;font-weight:600;">' + Math.round(p.moistureVal) + '%</span></div>' : '') +
+            (p.hasTemperature ? '<div class="detail-row"><span class="detail-label">Temperature</span><span class="detail-value" style="color:#ff9f43;font-weight:600;">' + Math.round(p.temperatureVal) + self._esc(p.temperatureUnit) + '</span></div>' : '') +
+            (p.hasHumidity    ? '<div class="detail-row"><span class="detail-label">Humidity</span><span class="detail-value" style="color:#54a0ff;font-weight:600;">' + Math.round(p.humidityVal) + self._esc(p.humidityUnit) + '</span></div>' : '') +
             (p.nextFertilized ? '<div class="detail-row"><span class="detail-label">Next fertilization</span><span class="detail-value">' + self._esc(p.nextFertilized) + '</span></div>' : '') +
             repottedRows +
             (p.healthEntityId ? '<div class="detail-row"><span class="detail-label">Health</span>' +

--- a/custom_components/adaptive_plant/plant.py
+++ b/custom_components/adaptive_plant/plant.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_ENABLE_REPOTTING,
     CONF_FERTILIZATION_ENABLED,
     CONF_HEALTH_PROMPT_INTERVAL,
+    CONF_HUMIDITY_SENSOR,
     CONF_IMAGE_PATH,
     CONF_LABEL,
     CONF_LATIN_NAME,
@@ -34,6 +35,7 @@ from .const import (
     CONF_PLANT_NAME,
     CONF_REPOTTING_ENABLED,
     CONF_SNOOZE_THRESHOLD,
+    CONF_TEMPERATURE_SENSOR,
     CONF_WET_THRESHOLD,
     DEFAULT_EARLY_WATERING_THRESHOLD,
     DEFAULT_FERT_SYNC_WINDOW,
@@ -220,6 +222,24 @@ class PlantData:
     def wet_threshold(self) -> float | None:
         val = self._entry.options.get(CONF_WET_THRESHOLD) if CONF_WET_THRESHOLD in self._entry.options else self._entry.data.get(CONF_WET_THRESHOLD)
         return float(val) if val is not None else None
+
+    @property
+    def temperature_sensor(self) -> str | None:
+        # Display-only passthrough. Same key-presence + empty-string-tombstone
+        # resolution as moisture_sensor so toggling it off in the options flow
+        # shadows the entry.data value chosen during the setup wizard.
+        if CONF_TEMPERATURE_SENSOR in self._entry.options:
+            val = self._entry.options[CONF_TEMPERATURE_SENSOR]
+            return val if val else None
+        return self._entry.data.get(CONF_TEMPERATURE_SENSOR)
+
+    @property
+    def humidity_sensor(self) -> str | None:
+        # Display-only passthrough; see temperature_sensor.
+        if CONF_HUMIDITY_SENSOR in self._entry.options:
+            val = self._entry.options[CONF_HUMIDITY_SENSOR]
+            return val if val else None
+        return self._entry.data.get(CONF_HUMIDITY_SENSOR)
 
     # ── Mutable config ───────────────────────────────────────────────────────────
 

--- a/custom_components/adaptive_plant/sensor.py
+++ b/custom_components/adaptive_plant/sensor.py
@@ -28,6 +28,8 @@ async def async_setup_entry(
         EarlyWateringCountSensor(plant, entry),
         SnoozeCountSensor(plant, entry),
         CurrentMoistureSensor(plant, entry),
+        CurrentTemperatureSensor(plant, entry),
+        CurrentHumiditySensor(plant, entry),
     ]
 
     if plant.enable_fertilization:
@@ -259,26 +261,25 @@ class DaysUntilFertilizingSensor(PlantSensorBase):
         return f"In {days} Days"
 
 
-class CurrentMoistureSensor(PlantSensorBase):
-    """Diagnostic sensor that mirrors the linked moisture sensor's current reading.
+class LinkedSensorMirror(PlantSensorBase):
+    """Diagnostic passthrough that mirrors a linked external sensor's reading.
 
-    Always created so it appears on the device page in the HA integration panel.
-    Disabled by default when no moisture sensor is configured; automatically
-    enabled once a sensor is assigned. The direct source subscription re-points
-    itself when the linked sensor is changed in options, so no entry reload is
-    required.
+    Generalises the moisture-mirror pattern for display-only environment
+    parameters. Subclasses set the device class / icon / translation key /
+    unique-id suffix and override `_linked_sensor_id` to return the linked
+    entity id from PlantData.
+
+    Always created so it shows on the device page; `available` gates whether a
+    reading is shown — unavailable when no sensor is linked or the source is
+    unavailable. The unit follows the source sensor so °C/°F (etc.) is honoured.
+    The direct source subscription re-points itself when the linked sensor is
+    changed in options, so no entry reload is required.
     """
 
-    _attr_translation_key = "current_moisture"
-    _attr_icon = "mdi:water-percent"
-    _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_device_class = SensorDeviceClass.MOISTURE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = "%"
 
     def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
         super().__init__(plant, entry)
-        self._attr_unique_id = f"{entry.entry_id}_current_moisture"
         # Always enabled — availability is controlled dynamically via the
         # `available` property below. When no sensor is configured the entity
         # shows as unavailable rather than requiring manual enable/disable.
@@ -290,8 +291,12 @@ class CurrentMoistureSensor(PlantSensorBase):
         self._tracked_source_id: str | None = None
 
     @property
+    def _linked_sensor_id(self) -> str | None:
+        raise NotImplementedError
+
+    @property
     def native_value(self) -> float | None:
-        sensor_id = self._plant.moisture_sensor
+        sensor_id = self._linked_sensor_id
         if not sensor_id:
             return None
         state = self.hass.states.get(sensor_id)
@@ -302,16 +307,29 @@ class CurrentMoistureSensor(PlantSensorBase):
         except (ValueError, TypeError):
             return None
 
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        # Follow the source sensor's unit; fall back to the subclass default
+        # only when the source declares none.
+        sensor_id = self._linked_sensor_id
+        if sensor_id:
+            state = self.hass.states.get(sensor_id)
+            if state is not None:
+                unit = state.attributes.get("unit_of_measurement")
+                if unit:
+                    return unit
+        return self._attr_native_unit_of_measurement
+
     def _resubscribe_source(self) -> None:
         # (Re)point the direct source subscription at the currently-linked
         # sensor. Idempotent: a no-op while the id is unchanged, so it is cheap
         # to call on every PlantData notification.
         #
         # NOTE: do not remove this in favor of the PlantData listener alone.
-        # handle_moisture_change only persists on threshold crossings, so
-        # without this direct subscription the mirror (and the card) would go
-        # stale between crossings. Two subscriptions are intentional.
-        sensor_id = self._plant.moisture_sensor
+        # PlantData only persists on discrete events (moisture threshold
+        # crossings; nothing at all for the display-only mirrors), so without
+        # this direct subscription the mirror (and the card) would go stale.
+        sensor_id = self._linked_sensor_id
         if sensor_id == self._tracked_source_id:
             return
         if self._source_unsub is not None:
@@ -349,11 +367,65 @@ class CurrentMoistureSensor(PlantSensorBase):
     @property
     def available(self) -> bool:
         """Unavailable when no sensor is configured or the sensor is unavailable."""
-        sensor_id = self._plant.moisture_sensor
+        sensor_id = self._linked_sensor_id
         if not sensor_id:
             return False
         state = self.hass.states.get(sensor_id)
         return state is not None and state.state not in ("unknown", "unavailable")
+
+
+class CurrentMoistureSensor(LinkedSensorMirror):
+    """Mirrors the linked soil-moisture sensor (also drives watering logic)."""
+
+    _attr_translation_key = "current_moisture"
+    _attr_icon = "mdi:water-percent"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.MOISTURE
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        super().__init__(plant, entry)
+        self._attr_unique_id = f"{entry.entry_id}_current_moisture"
+
+    @property
+    def _linked_sensor_id(self) -> str | None:
+        return self._plant.moisture_sensor
+
+
+class CurrentTemperatureSensor(LinkedSensorMirror):
+    """Mirrors the linked ambient temperature sensor (display only)."""
+
+    _attr_translation_key = "current_temperature"
+    _attr_icon = "mdi:thermometer"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = "°C"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        super().__init__(plant, entry)
+        self._attr_unique_id = f"{entry.entry_id}_current_temperature"
+
+    @property
+    def _linked_sensor_id(self) -> str | None:
+        return self._plant.temperature_sensor
+
+
+class CurrentHumiditySensor(LinkedSensorMirror):
+    """Mirrors the linked ambient humidity sensor (display only)."""
+
+    _attr_translation_key = "current_humidity"
+    _attr_icon = "mdi:water-percent"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.HUMIDITY
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, plant: PlantData, entry: ConfigEntry) -> None:
+        super().__init__(plant, entry)
+        self._attr_unique_id = f"{entry.entry_id}_current_humidity"
+
+    @property
+    def _linked_sensor_id(self) -> str | None:
+        return self._plant.humidity_sensor
 
 
 class LastRepottedSensor(PlantSensorBase):

--- a/custom_components/adaptive_plant/strings.json
+++ b/custom_components/adaptive_plant/strings.json
@@ -56,10 +56,14 @@
           "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
           "enable_repotting": "Track repotting",
-          "moisture_sensor": "Moisture sensor (optional)"
+          "moisture_sensor": "Moisture sensor (optional)",
+          "temperature_sensor": "Temperature sensor (optional)",
+          "humidity_sensor": "Humidity sensor (optional)"
         },
         "data_description": {
-          "moisture_sensor": "Select an existing sensor to drive automatic watering logic."
+          "moisture_sensor": "Select an existing sensor to drive automatic watering logic.",
+          "temperature_sensor": "Optional ambient temperature sensor to display on this plant.",
+          "humidity_sensor": "Optional ambient humidity sensor to display on this plant."
         }
       },
       "last_watered": {
@@ -178,7 +182,11 @@
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor",
           "dry_threshold": "Dry threshold (reschedule watering to today)",
-          "wet_threshold": "Wet threshold (auto-mark as watered)"
+          "wet_threshold": "Wet threshold (auto-mark as watered)",
+          "temperature_sensor_enabled": "Enable temperature sensor",
+          "temperature_sensor": "Temperature sensor",
+          "humidity_sensor_enabled": "Enable humidity sensor",
+          "humidity_sensor": "Humidity sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",
@@ -189,6 +197,10 @@
           "care_instructions": "Free-form care notes shown read-only on the card. Type \\*\\*bold\\*\\* to make text **bold**. Line breaks are supported.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic.",
+          "temperature_sensor_enabled": "Toggle off to remove the ambient temperature sensor.",
+          "temperature_sensor": "Ambient temperature sensor to display on this plant (no effect on watering).",
+          "humidity_sensor_enabled": "Toggle off to remove the ambient humidity sensor.",
+          "humidity_sensor": "Ambient humidity sensor to display on this plant (no effect on watering).",
           "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval.",
           "image_upload": "Pick a photo from your device (PNG/JPEG). Takes priority over the path below."
         }
@@ -266,6 +278,8 @@
       "next_fertilized": { "name": "Next fertilization" },
       "days_until_fertilizing": { "name": "Days until fertilization" },
       "current_moisture": { "name": "Soil moisture" },
+      "current_temperature": { "name": "Temperature" },
+      "current_humidity": { "name": "Humidity" },
       "last_repotted": { "name": "Last repotted" }
     },
     "button": {

--- a/custom_components/adaptive_plant/translations/en.json
+++ b/custom_components/adaptive_plant/translations/en.json
@@ -56,10 +56,14 @@
           "enable_latin_name": "Add a latin name field",
           "enable_image": "Show a plant image",
           "enable_repotting": "Track repotting",
-          "moisture_sensor": "Moisture sensor (optional)"
+          "moisture_sensor": "Moisture sensor (optional)",
+          "temperature_sensor": "Temperature sensor (optional)",
+          "humidity_sensor": "Humidity sensor (optional)"
         },
         "data_description": {
-          "moisture_sensor": "Select an existing sensor to drive automatic watering logic."
+          "moisture_sensor": "Select an existing sensor to drive automatic watering logic.",
+          "temperature_sensor": "Optional ambient temperature sensor to display on this plant.",
+          "humidity_sensor": "Optional ambient humidity sensor to display on this plant."
         }
       },
       "last_watered": {
@@ -178,7 +182,11 @@
           "moisture_sensor_enabled": "Enable moisture sensor",
           "moisture_sensor": "Moisture sensor",
           "dry_threshold": "Dry threshold (reschedule watering to today)",
-          "wet_threshold": "Wet threshold (auto-mark as watered)"
+          "wet_threshold": "Wet threshold (auto-mark as watered)",
+          "temperature_sensor_enabled": "Enable temperature sensor",
+          "temperature_sensor": "Temperature sensor",
+          "humidity_sensor_enabled": "Enable humidity sensor",
+          "humidity_sensor": "Humidity sensor"
         },
         "data_description": {
           "label": "Optional sublabel to group plants within an area (e.g. Left shelf, Window sill). Leave blank or enter 'null' to remove.",
@@ -189,6 +197,10 @@
           "care_instructions": "Free-form care notes shown read-only on the card. Type \\*\\*bold\\*\\* to make text **bold**. Line breaks are supported.",
           "moisture_sensor_enabled": "Toggle off to remove the moisture sensor and clear all thresholds.",
           "moisture_sensor": "Select a sensor to drive automatic watering logic.",
+          "temperature_sensor_enabled": "Toggle off to remove the ambient temperature sensor.",
+          "temperature_sensor": "Ambient temperature sensor to display on this plant (no effect on watering).",
+          "humidity_sensor_enabled": "Toggle off to remove the ambient humidity sensor.",
+          "humidity_sensor": "Ambient humidity sensor to display on this plant (no effect on watering).",
           "fertilization_sync_window": "When you mark this plant watered, an upcoming fertilization within this many days snaps onto the watering day so you can do both at once. 0 disables, leaving watering and fertilization intervals independent of one another. Keep it below the watering interval.",
           "image_upload": "Pick a photo from your device (PNG/JPEG). Takes priority over the path below."
         }
@@ -266,6 +278,8 @@
       "next_fertilized": { "name": "Next fertilization" },
       "days_until_fertilizing": { "name": "Days until fertilization" },
       "current_moisture": { "name": "Soil moisture" },
+      "current_temperature": { "name": "Temperature" },
+      "current_humidity": { "name": "Humidity" },
       "last_repotted": { "name": "Last repotted" }
     },
     "button": {


### PR DESCRIPTION
## What this adds

Per-plant **ambient temperature and humidity** sensors, alongside the existing soil-moisture link. Each is an optional entity you point at any existing temperature/humidity sensor; the plant's device then surfaces a mirror of that reading.

These are **display-only** — unlike moisture, they have no thresholds and no effect on watering/scheduling. The intent is to let a plant's device show its full local environment, not just soil moisture.

### Implementation

- **`const` / `plant`** — `CONF_TEMPERATURE_SENSOR` / `CONF_HUMIDITY_SENSOR`, with `temperature_sensor` / `humidity_sensor` properties using the same options→data fallback + empty-string-tombstone resolution as `moisture_sensor`.
- **`sensor`** — generalises the moisture mirror into a `LinkedSensorMirror` base (dynamic `native_value` / `available`, source-unit passthrough, and a self-re-pointing source subscription). `CurrentMoistureSensor` now subclasses it; `CurrentTemperatureSensor` / `CurrentHumiditySensor` are added. Both new entities are `DIAGNOSTIC` with `state_class=measurement`, matching the moisture mirror.
- **`config_flow`** — device-class-filtered entity pickers in the setup wizard and a toggle+picker pair in the options flow. The sensor keys are written into `cleaned` before the moisture branch splits and added to `_skip_clear`, so a disable tombstone survives the save (mirrors the moisture handling).
- **`strings` / `en`** — field/description/entity-name labels.
- **card** — temperature/humidity rows in the expanded plant detail view, beside the existing soil-moisture row; the unit follows the source sensor. (Overview pills/chips are left moisture-only, since those are watering-driven.)

Structured so range/`problem` alerting and further parameters (illuminance, conductivity, …) can follow the same base later.

## Relationship to #25

**This PR includes #25.** Its first commit (`4e7a5df`) is exactly the fix from #25; the rest generalises the moisture mirror into the shared base (which subsumes that fix) and adds the new parameters. So:

- **Want the whole feature?** Merge this — it carries the fix, so #25 can be closed.
- **Want only the bugfix for now?** Merge #25 instead and I'll rebase this on top. They're alternatives, not both-to-merge.

The fix is kept as a standalone first commit so it's reviewable on its own before the feature commits build on it.

## A couple of points for your call

- `state_class=measurement` means each mirror records its own long-term statistics, duplicating the source sensor's. I kept it for consistency with the moisture mirror (gives the plant device self-contained history), but happy to drop it if you'd rather not duplicate recorder data.
- The card change is intentionally minimal (detail rows only). Promoting these readings to the always-visible overview is a separate UX question I've left out of this PR.

Tested live on a real plant (temperature + humidity linked to a Zigbee2MQTT probe): mirrors track the source values and units, entry loads clean, no errors.
